### PR TITLE
Add formatter config option

### DIFF
--- a/pygal/config.py
+++ b/pygal/config.py
@@ -154,6 +154,10 @@ class Config(object):
         False, bool, "Value", "Display values in human readable format",
         "(ie: 12.4M)")
 
+    formatter = Key(
+        None, callable, "Value",
+        "Function used to convert values into human readable format")
+
     logarithmic = Key(
         False, bool, "Value", "Display values in logarithmic scale")
 

--- a/pygal/graph/base.py
+++ b/pygal/graph/base.py
@@ -80,7 +80,12 @@ class BaseGraph(object):
     @property
     def _format(self):
         """Return the value formatter for this graph"""
-        return humanize if self.human_readable else str
+        if self.formatter is not None:
+            return self.formatter
+        elif self.human_readable:
+            return humanize
+        else:
+            return str
 
     def _compute(self):
         """Initial computations to draw the graph"""


### PR DESCRIPTION
This adds a `formatter` option that lets user use their own function to convert numbers into human-readable values. The `human_readable` option is still here, but won't be used if `formatter` is provided.

I'm using this to convert seconds from "42165" to "11h 42m 45s", but I'm sure there are plenty of other ways to use this.
