### PR TITLE
add png visualization in ipython notebook

### DIFF
--- a/pygal/ghost.py
+++ b/pygal/ghost.py
@@ -102,3 +102,7 @@ class Ghost(object):
         """Render the graph, convert it to png and write it to filename"""
         import cairosvg
         return cairosvg.svg2png(bytestring=self.render(), write_to=filename)
+
+    def _repr_png_(self):
+        """Display png in IPython notebook"""
+        return self.render_to_png()


### PR DESCRIPTION
Add a _repr_png_ method to ghost to give a png preview of plots in the
notebook.

For example, entering the following into a cell will display a graph:

``` python
import pygal                                                       # First import pygal
bar_chart = pygal.Bar()                                            # Then create a bar graph object
bar_chart.add('Fibonacci', [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55])  # Add some values
bar_chart
```
