### PR TITLE
x axis limiter for labels for line graph

### DIFF
--- a/pygal/config.py
+++ b/pygal/config.py
@@ -140,6 +140,11 @@ class Config(object):
         "Leave it to None to disable x labels display.",
         str)
 
+    x_labels_num_limit = Key(None, int, "Label", 
+            "Limits the number of X labels, defaults to None",
+            "If none, there will be as many x labels as provided in x_labels. When provided - limits the number of X labels"
+            )
+
     y_labels = Key(
         None, list, "Label",
         "You can specify explicit y labels",

--- a/pygal/graph/line.py
+++ b/pygal/graph/line.py
@@ -104,7 +104,13 @@ class Line(Graph):
             self._box.ymin, self._box.ymax, self.logarithmic, self.order_min
         ) if not self.y_labels else map(float, self.y_labels)
 
-        self._x_labels = self.x_labels and zip(self.x_labels, x_pos)
+        x_labels = zip(self.x_labels, x_pos)
+
+        if self.x_labels_num_limit and len(x_labels)>self.x_labels_num_limit:
+            step = (len(x_labels)-1)/(self.x_labels_num_limit-1)
+            x_labels = list(x_labels[int(i*step)] for i in range(self.x_labels_num_limit))
+
+        self._x_labels = self.x_labels and x_labels
         self._y_labels = zip(map(self._format, y_pos), y_pos)
 
     def _plot(self):


### PR DESCRIPTION
This patch allows for limitation of x-labels on line and stacked line graphs, so if someone has a lot of data to show, x-axis doesn't get cluttered with too many values.
