### PR TITLE
Change location of default javascript files

### DIFF
--- a/pages/other_customizations.rst
+++ b/pages/other_customizations.rst
@@ -42,8 +42,8 @@ Default:
 
     css = ['style.css', 'graph.css']
     js = [
-        'https://raw.github.com/Kozea/pygal.js/master/svg.jquery.js',
-        'https://raw.github.com/Kozea/pygal.js/master/pygal-tooltips.js'
+        'http://kozea.github.com/pygal.js/javascripts/svg.jquery.js',
+        'http://kozea.github.com/pygal.js/javascripts/pygal-tooltips.js'
     ]
 
 


### PR DESCRIPTION
(Windows/Firefox) js files from pygal.js were not recognized properly from the raw.github.com domain, switching to the pages-generated kozea.github.io fixes this.
