### PR TITLE
Fix bug with None y-values for charts with a secondary y-axis.

### DIFF
--- a/pygal/graph/line.py
+++ b/pygal/graph/line.py
@@ -60,9 +60,11 @@ class Line(Graph):
     def line(self, serie_node, serie, rescale=False):
         """Draw the line serie"""
         if rescale and self.secondary_series:
-            points = [
-                (x, self._scale_diff + (y - self._scale_min_2nd) * self._scale)
-                for x, y in serie.points]
+            points = []
+            for x, y in serie.points:
+                if y is not None:
+                    y = self._scale_diff + (y - self._scale_min_2nd) * self._scale
+                points.append((x, y))
         else:
             points = serie.points
         view_values = list(map(self.view, points))


### PR DESCRIPTION
Otherwise the following exception is thrown:

```
Exception: unsupported operand type(s) for -: 'NoneType' and 'float'
```
