### PR TITLE
Prevent automatic x-axis label truncation from being less than 1

### DIFF
--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -135,6 +135,7 @@ class Graph(BaseGraph):
                         len(self._x_labels) - 1)
                 truncation = reverse_text_len(
                     available_space, self.label_font_size)
+                truncation = max(truncation, 1)
 
         if 0 not in [label[1] for label in self._x_labels]:
             self.svg.node(axis, 'path',


### PR DESCRIPTION
When there are more x-axis labels than there are pixels of space the division will result in `truncation` being equal to zero. This causes truncation of x-axis labels to be completely bypassed as the `truncate()` function ignores truncations that are equal to 0. 

This patch makes 1 the minimum which means that in the worst case all the x-axis labels will be displayed as '...'. I think this is preferable to having the full labels positioned on top of one another.
