### PR TITLE
Use hasattr instead of dir

### DIFF
--- a/pygal/graph/base.py
+++ b/pygal/graph/base.py
@@ -70,7 +70,7 @@ class BaseGraph(object):
 
     def __getattr__(self, attr):
         """Search in config, then in self"""
-        if attr in dir(self.config):
+        if hasattr(self.config, attr):
             return object.__getattribute__(self.config, attr)
         return object.__getattribute__(self, attr)
 


### PR DESCRIPTION
`dir()` is insanely slow since it has to create and sort a list each time. Switching to `hasattr` provides a nice 10x speedup.
