### PR TITLE
ADDS HOOK FOR XML MODIFICATION PRE-RENDERING

### DIFF
--- a/pygal/ghost.py
+++ b/pygal/ghost.py
@@ -60,6 +60,7 @@ class Ghost(object):
         self.config = config
         self.raw_series = []
         self.raw_series2 = []
+        self.xml_filters = []
 
     def add(self, title, values, secondary=False):
         """Add a serie to this graph"""
@@ -70,6 +71,9 @@ class Ghost(object):
         else:
             self.raw_series.append((title, values))
 
+    def add_xml_filter(self, callback):
+        self.xml_filters.append(callback)
+        
     def make_series(self, series):
         return prepare_values(series, self.config, self.cls)
 
@@ -79,7 +83,8 @@ class Ghost(object):
         series = self.make_series(self.raw_series)
         secondary_series = self.make_series(self.raw_series2)
         self._last__inst = self.cls(
-            self.config, series, secondary_series, self.uuid)
+            self.config, series, secondary_series, self.uuid,
+            self.xml_filters)
         return self._last__inst
 
     # Rendering

--- a/pygal/graph/base.py
+++ b/pygal/graph/base.py
@@ -35,13 +35,14 @@ class BaseGraph(object):
 
     _adapters = []
 
-    def __init__(self, config, series, secondary_series, uuid):
+    def __init__(self, config, series, secondary_series, uuid, xml_filters):
         """Init the graph"""
         self.uuid = uuid
         self.__dict__.update(config.to_dict())
         self.config = config
         self.series = series or []
         self.secondary_series = secondary_series or []
+        self.xml_filters = xml_filters or []
         self.horizontal = getattr(self, 'horizontal', False)
         self.svg = Svg(self)
         self._x_labels = None
@@ -252,4 +253,7 @@ class BaseGraph(object):
 
     def render_tree(self):
         """Render the graph, and return lxml tree"""
-        return self.svg.root
+        svg = self.svg.root
+        for f in self.xml_filters:
+            svg = f(svg)
+        return svg

--- a/pygal/svg.py
+++ b/pygal/svg.py
@@ -217,6 +217,8 @@ class Svg(object):
 
     def render(self, is_unicode=False, pretty_print=False):
         """Last thing to do before rendering"""
+        for f in self.graph.xml_filters:
+            self.root = f(self.root)
         svg = etree.tostring(
             self.root, pretty_print=pretty_print,
             xml_declaration=False,


### PR DESCRIPTION
An XML filter can be defined as a function taking a single argument,
supplied as the 'svg' atribute of the graph (an lxml etree?) and
returning a modified version/copy thereof.

XML filters can be added to a plot using the new plot method
add_xml_filter(func).

The hook that executes any filters added to the plot, executes them in
order immediately prior to conversion to a string, in the class method
svg.render, and also immediately prior to returning a copy of the tree
in BaseGraph.render_tree
