### PR TITLE
Fix a bug with secondary y-axis and formatted values

### DIFF
--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -495,10 +495,9 @@ class Graph(BaseGraph):
             self._y_2nd_labels = [(self._format(ymin + i * scale), pos)
                                   for i, pos in enumerate(y_pos)]
 
-            min_2nd = float(self._y_2nd_labels[0][0])
             self._scale = left_range / right_range
             self._scale_diff = y_pos[0]
-            self._scale_min_2nd = min_2nd
+            self._scale_min_2nd = ymin
 
     def _post_compute(self):
         pass


### PR DESCRIPTION
_y_2nd_labels will contain strings that will sometimes be human formatted and not cast-able to a float.
