### PR TITLE
Add formatting to the DateY X axis label

### DIFF
--- a/pygal/config.py
+++ b/pygal/config.py
@@ -213,6 +213,9 @@ class Config(object):
     y_label_rotation = Key(
         0, int, "Label", "Specify y labels rotation angles", "in degrees")
 
+    x_label_format = Key(
+        "%Y-%m-%d %H:%M:%S.%f", str, "Label", "Date format for strftime to display the DateY X labels")
+
     ############ Value ############
     human_readable = Key(
         False, bool, "Value", "Display values in human readable format",

--- a/pygal/graph/datey.py
+++ b/pygal/graph/datey.py
@@ -50,7 +50,8 @@ class DateY(XY):
 
     def _todate(self, d):
         """ Converts a number to a date """
-        return str(self._offset + datetime.timedelta(seconds=d or 0))
+        currDateTime = self._offset + datetime.timedelta(seconds=d or 0)
+        return currDateTime.strftime( self.x_label_format )
 
     def _tonumber(self, d):
         """ Converts a date to a number """


### PR DESCRIPTION
Allow formatting other than the default for the X axis on the DateY plots.
This is done by setting
datey.x_label_format = "%Y-%m-%d"

The formatting is done by the strftime function, so any valid format will work.
See: http://docs.python.org/2/library/time.html#time.strftime
