### PR TITLE
Allow arbitrary number of x-labels on line plot

### DIFF
--- a/pygal/graph/line.py
+++ b/pygal/graph/line.py
@@ -110,7 +110,14 @@ class Line(Graph):
         self._points(x_pos)
 
         if self.x_labels:
-            self._x_labels = list(zip(self.x_labels, x_pos))
+            label_len = len(self.x_labels)
+            if label_len != self._len:
+                label_pos = [0.5] if label_len == 1 else [
+                    x / (label_len - 1) for x in range(label_len)
+                ]
+                self._x_labels = list(zip(self.x_labels, label_pos))
+            else:
+                self._x_labels = list(zip(self.x_labels, x_pos))
         else:
             self._x_labels = None
 

--- a/pygal/test/test_line.py
+++ b/pygal/test/test_line.py
@@ -81,3 +81,14 @@ def test_no_dot():
 def test_no_dot_at_all():
     q = Line().render_pyquery()
     assert q(".text-overlay text").text() == 'No data'
+
+
+def test_not_equal_x_labels():
+    line = Line()
+    line.add('test1', range(100))
+    line.x_labels = map(str, range(11))
+    q = line.render_pyquery()
+    assert len(q(".dots")) == 100
+    assert len(q(".axis.x")) == 1
+    assert q(".axis.x text").map(texts) == ['0', '1', '2', '3', '4', '5', '6',
+                                            '7', '8', '9', '10']


### PR DESCRIPTION
When there are thousands of points in a line plot.
It is sensible to show only some of the ticks for x labels.
