### PR TITLE
Fix ZeroDivisionError in sparktext rendering

### DIFF
--- a/pygal/ghost.py
+++ b/pygal/ghost.py
@@ -146,6 +146,11 @@ class Ghost(object):
         vmax = max(values)
         if relative_to is None:
             relative_to = min(values)
+
+        if (vmax - relative_to) == 0:
+            chart = bars[0] * len(values)
+            return chart
+
         divisions = len(bars) - 1
         for value in values:
             chart += bars[int(divisions *

--- a/pygal/test/test_sparktext.py
+++ b/pygal/test/test_sparktext.py
@@ -60,3 +60,13 @@ def test_negative_and_float_and_no_data_sparktext():
 
     chart3 = Line()
     assert chart3.render_sparktext() == u('')
+
+
+def test_same_max_and_relative_values_sparktext():
+    chart = Line()
+    chart.add('_', [0, 0, 0, 0, 0])
+    assert chart.render_sparktext() == u('▁▁▁▁▁')
+
+    chart2 = Line()
+    chart2.add('_', [1, 1, 1, 1, 1])
+    assert chart2.render_sparktext(relative_to=1) == u('▁▁▁▁▁')


### PR DESCRIPTION
This fixes a ZeroDivisionError when rendering sparktext if the max value and relative_to values are the same.
