### PR TITLE
Normalize Naming of Chart Examples

### DIFF
--- a/pages/chart_types.rst
+++ b/pages/chart_types.rst
@@ -35,13 +35,13 @@ Same graph but with stacked values and filled rendering:
 
 .. pygal-code::
 
-  line_chart = pygal.StackedLine(fill=True)
-  line_chart.title = 'Browser usage evolution (in %)'
-  line_chart.x_labels = map(str, range(2002, 2013))
-  line_chart.add('Firefox', [None, None, 0, 16.6,   25,   31, 36.4, 45.5, 46.3, 42.8, 37.1])
-  line_chart.add('Chrome',  [None, None, None, None, None, None,    0,  3.9, 10.8, 23.8, 35.3])
-  line_chart.add('IE',      [85.8, 84.6, 84.7, 74.5,   66, 58.6, 54.7, 44.8, 36.2, 26.6, 20.1])
-  line_chart.add('Others',  [14.2, 15.4, 15.3,  8.9,    9, 10.4,  8.9,  5.8,  6.7,  6.8,  7.5])
+  stackedline_chart = pygal.StackedLine(fill=True)
+  stackedline_chart.title = 'Browser usage evolution (in %)'
+  stackedline_chart.x_labels = map(str, range(2002, 2013))
+  stackedline_chart.add('Firefox', [None, None, 0, 16.6,   25,   31, 36.4, 45.5, 46.3, 42.8, 37.1])
+  stackedline_chart.add('Chrome',  [None, None, None, None, None, None,    0,  3.9, 10.8, 23.8, 35.3])
+  stackedline_chart.add('IE',      [85.8, 84.6, 84.7, 74.5,   66, 58.6, 54.7, 44.8, 36.2, 26.6, 20.1])
+  stackedline_chart.add('Others',  [14.2, 15.4, 15.3,  8.9,    9, 10.4,  8.9,  5.8,  6.7,  6.8,  7.5])
 
 
 Bar charts / Histograms
@@ -54,13 +54,13 @@ Basic simple bar graph:
 
 .. pygal-code::
 
-  line_chart = pygal.Bar()
-  line_chart.title = 'Browser usage evolution (in %)'
-  line_chart.x_labels = map(str, range(2002, 2013))
-  line_chart.add('Firefox', [None, None, 0, 16.6,   25,   31, 36.4, 45.5, 46.3, 42.8, 37.1])
-  line_chart.add('Chrome',  [None, None, None, None, None, None,    0,  3.9, 10.8, 23.8, 35.3])
-  line_chart.add('IE',      [85.8, 84.6, 84.7, 74.5,   66, 58.6, 54.7, 44.8, 36.2, 26.6, 20.1])
-  line_chart.add('Others',  [14.2, 15.4, 15.3,  8.9,    9, 10.4,  8.9,  5.8,  6.7,  6.8,  7.5])
+  bar_chart = pygal.Bar()
+  bar_chart.title = 'Browser usage evolution (in %)'
+  bar_chart.x_labels = map(str, range(2002, 2013))
+  bar_chart.add('Firefox', [None, None, 0, 16.6,   25,   31, 36.4, 45.5, 46.3, 42.8, 37.1])
+  bar_chart.add('Chrome',  [None, None, None, None, None, None,    0,  3.9, 10.8, 23.8, 35.3])
+  bar_chart.add('IE',      [85.8, 84.6, 84.7, 74.5,   66, 58.6, 54.7, 44.8, 36.2, 26.6, 20.1])
+  bar_chart.add('Others',  [14.2, 15.4, 15.3,  8.9,    9, 10.4,  8.9,  5.8,  6.7,  6.8,  7.5])
 
 
 Stacked
@@ -70,13 +70,13 @@ Same graph but with stacked values:
 
 .. pygal-code::
 
-  line_chart = pygal.StackedBar()
-  line_chart.title = 'Browser usage evolution (in %)'
-  line_chart.x_labels = map(str, range(2002, 2013))
-  line_chart.add('Firefox', [None, None, 0, 16.6,   25,   31, 36.4, 45.5, 46.3, 42.8, 37.1])
-  line_chart.add('Chrome',  [None, None, None, None, None, None,    0,  3.9, 10.8, 23.8, 35.3])
-  line_chart.add('IE',      [85.8, 84.6, 84.7, 74.5,   66, 58.6, 54.7, 44.8, 36.2, 26.6, 20.1])
-  line_chart.add('Others',  [14.2, 15.4, 15.3,  8.9,    9, 10.4,  8.9,  5.8,  6.7,  6.8,  7.5])
+  stackedbar_chart = pygal.StackedBar()
+  stackedbar_chart.title = 'Browser usage evolution (in %)'
+  stackedbar_chart.x_labels = map(str, range(2002, 2013))
+  stackedbar_chart.add('Firefox', [None, None, 0, 16.6,   25,   31, 36.4, 45.5, 46.3, 42.8, 37.1])
+  stackedbar_chart.add('Chrome',  [None, None, None, None, None, None,    0,  3.9, 10.8, 23.8, 35.3])
+  stackedbar_chart.add('IE',      [85.8, 84.6, 84.7, 74.5,   66, 58.6, 54.7, 44.8, 36.2, 26.6, 20.1])
+  stackedbar_chart.add('Others',  [14.2, 15.4, 15.3,  8.9,    9, 10.4,  8.9,  5.8,  6.7,  6.8,  7.5])
 
 
 Horizontal
@@ -86,13 +86,13 @@ Horizontal bar diagram:
 
 .. pygal-code::
 
-  line_chart = pygal.HorizontalBar()
-  line_chart.title = 'Browser usage in February 2012 (in %)'
-  line_chart.add('IE', 19.5)
-  line_chart.add('Firefox', 36.6)
-  line_chart.add('Chrome', 36.3)
-  line_chart.add('Safari', 4.5)
-  line_chart.add('Opera', 2.3)
+  horizontalbar_chart = pygal.HorizontalBar()
+  horizontalbar_chart.title = 'Browser usage in February 2012 (in %)'
+  horizontalbar_chart.add('IE', 19.5)
+  horizontalbar_chart.add('Firefox', 36.6)
+  horizontalbar_chart.add('Chrome', 36.3)
+  horizontalbar_chart.add('Safari', 4.5)
+  horizontalbar_chart.add('Opera', 2.3)
 
 
 XY charts
@@ -174,13 +174,13 @@ Same pie but divided in sub category:
 
 .. pygal-code::
 
-  pie_chart = pygal.Pie()
-  pie_chart.title = 'Browser usage by version in February 2012 (in %)'
-  pie_chart.add('IE', [5.7, 10.2, 2.6, 1])
-  pie_chart.add('Firefox', [.6, 16.8, 7.4, 2.2, 1.2, 1, 1, 1.1, 4.3, 1])
-  pie_chart.add('Chrome', [.3, .9, 17.1, 15.3, .6, .5, 1.6])
-  pie_chart.add('Safari', [4.4, .1])
-  pie_chart.add('Opera', [.1, 1.6, .1, .5])
+  multipie_chart = pygal.Pie()
+  multipie_chart.title = 'Browser usage by version in February 2012 (in %)'
+  multipie_chart.add('IE', [5.7, 10.2, 2.6, 1])
+  multipie_chart.add('Firefox', [.6, 16.8, 7.4, 2.2, 1.2, 1, 1, 1.1, 4.3, 1])
+  multipie_chart.add('Chrome', [.3, .9, 17.1, 15.3, .6, .5, 1.6])
+  multipie_chart.add('Safari', [4.4, .1])
+  multipie_chart.add('Opera', [.1, 1.6, .1, .5])
 
 
 Radar charts


### PR DESCRIPTION
It started with `bar_chart` being `line_chart`, and then went downhill from there :)
