### PR TITLE
Added new mode to box plot chart: "extremes"

### DIFF
--- a/pygal/graph/box.py
+++ b/pygal/graph/box.py
@@ -159,10 +159,15 @@ class Box(Graph):
             sum(quartiles) / len(quartiles)))
 
     @staticmethod
-    def _box_points(values):
+    def _box_points(values, mode='1.5IQR'):
         """
-        Return a 5-tuple of Q1 - 1.5 * IQR, Q1, Median, Q3,
+        Default mode: (mode='1.5IQR' or unset)
+            Return a 5-tuple of Q1 - 1.5 * IQR, Q1, Median, Q3,
         and Q3 + 1.5 * IQR for a list of numeric values.
+        Extremes mode: (mode='extremes')
+            Return a 5-tuple of minimum, Q1, Median, Q3,
+        and maximum for a list of numeric values.
+
 
         The iterator values may include None values.
 
@@ -202,6 +207,10 @@ class Box(Graph):
                     q3 = 0.25 * s[3*m+1] + 0.75 * s[3*m+2]
 
             iqr = q3 - q1
-            q0 = q1 - 1.5 * iqr
-            q4 = q3 + 1.5 * iqr
+            if mode == 'extremes':
+                q0 = min(s)
+                q4 = max(s)
+            else:
+                q0 = q1 - 1.5 * iqr
+                q4 = q3 + 1.5 * iqr
             return q0, q1, q2, q3, q4

--- a/pygal/test/test_box.py
+++ b/pygal/test/test_box.py
@@ -49,6 +49,35 @@ def test_quartiles():
     assert q3 == 4
     assert q4 == 4
 
+def test_quartiles_min_extremes():
+    a = [-2.0, 3.0, 4.0, 5.0, 8.0]  # odd test data
+    q0, q1, q2, q3, q4 = Box._box_points(a, mode='extremes')
+
+    assert q1 == 7.0 / 4.0
+    assert q2 == 4.0
+    assert q3 == 23 / 4.0
+    assert q0 == -2.0  # min
+    assert q4 == 8.0  # max
+
+    b = [1.0, 4.0, 6.0, 8.0]  # even test data
+    q0, q1, q2, q3, q4 = Box._box_points(b, mode='extremes')
+
+    assert q2 == 5.0
+
+    c = [2.0, None, 4.0, 6.0, None]  # odd with None elements
+    q0, q1, q2, q3, q4 = Box._box_points(c, mode='extremes')
+
+    assert q2 == 4.0
+
+    d = [4]
+    q0, q1, q2, q3, q4 = Box._box_points(d, mode='extremes')
+
+    assert q0 == 4
+    assert q1 == 4
+    assert q2 == 4
+    assert q3 == 4
+    assert q4 == 4
+
 
 def test_simple_box():
     box = ghostedBox()


### PR DESCRIPTION
This mode change q0 and q4 to the minimum and the maximum values, respectively, allowing uses to decide whether they want to plot the extreme values or the 1.5 IQR distance.
