### PR TITLE
Reorders axes in SVG output. Fix #145

### DIFF
--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -47,8 +47,8 @@ class Graph(BaseGraph):
 
     def _axes(self):
         """Draw axes"""
-        self._x_axis()
         self._y_axis()
+        self._x_axis()
 
     def _set_view(self):
         """Assign a view to current graph"""


### PR DESCRIPTION
Currently pygal renders the x-axis before the y-axis, but this means
that because of the painters algorithm, the horizontal guide lines of
the y-axis are above the y-axis line (which is actually an x-axis
guide). If you have custom css that changes the colours of horizontal
guide lines, for example to hide them until hovered over, they create
visual gaps in the y-axis.
