### PR TITLE
Adds config option (missing_value_fill_truncation). Fix #150

### DIFF
--- a/pygal/config.py
+++ b/pygal/config.py
@@ -303,6 +303,10 @@ class Config(CommonConfig):
         "%Y-%m-%d %H:%M:%S.%f", str, "Label",
         "Date format for strftime to display the DateY X labels")
 
+    missing_value_fill_truncation = Key(
+        "x", str, "Look",
+        "Filled series with missing x and/or y values at the end of a series are closed at the first value with a missing 'x' (default), 'y' or 'either'")
+
     # Value #
     human_readable = Key(
         False, bool, "Value", "Display values in human readable format",

--- a/pygal/graph/line.py
+++ b/pygal/graph/line.py
@@ -56,11 +56,21 @@ class Line(Graph):
 
         # Check to see if the data has been padded with "none's"
         # Fill doesn't work correctly otherwise
-        end = -1
-        for i, (x, y) in enumerate(reversed(values)):
-            if x is not None:
-                end = -1 - i
-                break
+        end = len(values)-1
+        while end > 0:
+            x, y = values[end]
+            if self.missing_value_fill_truncation == "either":
+                if x is not None and y is not None:
+                    break
+            elif self.missing_value_fill_truncation == "x":
+                if x is not None:
+                    break
+            elif self.missing_value_fill_truncation == "y":
+                if y is not None:
+                    break
+            else:
+                raise ValueError("Invalid value ({}) for config key 'missing_value_fill_truncation'; Use 'x', 'y' or 'either'".format(self.missing_value_fill_truncation))
+            end -= 1
 
         return ([(values[0][0], zero)] +
                 values +


### PR DESCRIPTION
Adds config option (missing_value_fill_truncation) which controls which
values (x, y, or either) in a series are checked for missing values when
determining where to place the closing point of a filled series path.

Commissioned by ClearSpark (http://www.clearspark.co.za)
