### PR TITLE
Add line stroke customization parameters to style.py

### DIFF
--- a/pygal/css/style.css
+++ b/pygal/css/style.css
@@ -100,6 +100,13 @@
   fill-opacity:  {{ style.opacity_hover }};
 }
 
+{{ id }}.series {
+  stroke-width: {{ style.stroke_width }};
+  stroke-linejoin: {{ style.stroke_style }};
+  stroke-linecap: {{ style.stroke_style }};
+  stroke-dasharray: {{ style.stroke_dasharray }};
+}
+
 {{ id }}.series text {
   fill: {{ style.foreground_light }};
 }

--- a/pygal/style.py
+++ b/pygal/style.py
@@ -24,7 +24,9 @@ from pygal.util import cycle_fill
 from pygal import colors
 from pygal.colors import darken, lighten
 import sys
+import re
 
+re_dasharray_delimiters = re.compile(r'[\.|,|x|\||\- ]+', re.I)
 
 class Style(object):
     """Styling class containing colors for the css generation"""
@@ -38,6 +40,9 @@ class Style(object):
             font_family='monospace',  # Monospaced font is highly encouraged
             opacity='.8',
             opacity_hover='.9',
+            stroke_width='1',
+            stroke_style='round',
+            stroke_dasharray=(0,0),
             transition='250ms',
             colors=(
                 '#ff5995', '#b6e354', '#feed6c', '#8cedff', '#9e6ffe',
@@ -52,8 +57,33 @@ class Style(object):
         self.font_family = font_family
         self.opacity = opacity
         self.opacity_hover = opacity_hover
+        self.stroke_width = stroke_width
+        self.stroke_style = stroke_style
+        self.stroke_dasharray = stroke_dasharray
         self.transition = transition
         self.colors = colors
+
+        self.validate_stroke_values()
+
+    def validate_stroke_values(self):
+        # stroke_width
+        self.stroke_width = float(self.stroke_width)
+
+        # stroke_style
+        self.stroke_style = self.stroke_style.lower().strip()
+        if not self.stroke_style in ['round', 'bevel', 'miter']:
+            self.stroke_style = 'round'
+
+        # stroke_dasharray
+        if isinstance(self.stroke_dasharray, (list, tuple)):
+            self.stroke_dasharray = '%d,%d' % self.stroke_dasharray
+
+        if isinstance(self.stroke_dasharray, str):
+            self.stroke_dasharray = re.sub(re_dasharray_delimiters, ',', self.stroke_dasharray)
+
+        if not isinstance(self.stroke_dasharray, str):
+            raise ValueError('stroke_dasharray not in proper form: tuple(int,int)')
+
 
     def get_colors(self, prefix):
         """Get the css color list"""

--- a/pygal/test/test_style.py
+++ b/pygal/test/test_style.py
@@ -16,6 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with pygal. If not, see <http://www.gnu.org/licenses/>.
+from pygal.style import Style
 from pygal import Line
 from pygal.style import (
     LightStyle,
@@ -42,3 +43,35 @@ def test_parametric_styles_with_parameters():
     line.add('_', [1, 2, 3])
     line.x_labels = 'abc'
     assert line.render()
+
+def test_stroke_style():
+    s = Style(stroke_style = 'round')
+    assert s.stroke_style == 'round'
+    s = Style(stroke_style = 'bevel')
+    assert s.stroke_style == 'bevel'
+    s = Style(stroke_style = 'miter')
+    assert s.stroke_style == 'miter'
+    s = Style(stroke_style = 'rounded')
+    assert s.stroke_style == 'round'
+    s = Style(stroke_style = 'invalid derp')
+    assert s.stroke_style == 'round'
+
+def test_stroke_dasharray():
+    s = Style(stroke_dasharray = (0,0))
+    assert s.stroke_dasharray == '0,0'
+    s = Style(stroke_dasharray = (.5,.5))
+    assert s.stroke_dasharray == '0,0'
+    s = Style(stroke_dasharray = (.9,.9))
+    assert s.stroke_dasharray == '0,0'
+    s = Style(stroke_dasharray = (1.9,1.9))
+    assert s.stroke_dasharray == '1,1'
+
+def test_stroke_dasharray_input_types():
+    s = Style(stroke_dasharray = (0,0))
+    assert s.stroke_dasharray == '0,0'
+    s = Style(stroke_dasharray = '0,0')
+    assert s.stroke_dasharray == '0,0'
+    s = Style(stroke_dasharray = '0x0')
+    assert s.stroke_dasharray == '0,0'
+    s = Style(stroke_dasharray = '0  0')
+    assert s.stroke_dasharray == '0,0'


### PR DESCRIPTION
Added stroke_width, stroke_style and stroke_dasharray to style.py -- defaults are such that the original style remains the same, but now one can further customize the look of the lines in their graphs. I also added the appropriate unit tests.

Sample:

```
import pygal

config = pygal.Config()

config.dots_size = 0

custom_style = pygal.style.Style(
    stroke_width = 3,
    stroke_style = "miter",
    stroke_dasharray = '5,5'
)

line_chart = pygal.Line(config, style = custom_style)
line_chart.title = 'Browser usage evolution (in %)'
line_chart.x_labels = map(str, range(2002, 2013))
line_chart.add('Firefox', [None, None, 0, 16.6,   25,   31, 36.4, 45.5, 46.3, 42.8, 37.1])
line_chart.add('Chrome',  [None, None, None, None, None, None,    0,  3.9, 10.8, 23.8, 35.3])
line_chart.add('IE',      [85.8, 84.6, 84.7, 74.5,   66, 58.6, 54.7, 44.8, 36.2, 26.6, 20.1])
line_chart.add('Others',  [14.2, 15.4, 15.3,  8.9,    9, 10.4,  8.9,  5.8,  6.7,  6.8,  7.5])
line_chart.render_in_browser()
```
