### PR TITLE
Adjust render_django_response() to Django>1.4

### DIFF
--- a/pygal/ghost.py
+++ b/pygal/ghost.py
@@ -142,11 +142,11 @@ class Ghost(object):
         """Render the graph, and return a Flask response"""
         from flask import Response
         return Response(self.render(**kwargs), mimetype='image/svg+xml')
-        
+
     def render_django_response(self, **kwargs):
         """Render the graph, and return a Django response"""
         from django.http import HttpResponse
-        return HttpResponse(self.render(**kwargs), mimetype='image/svg+xml')
+        return HttpResponse(self.render(**kwargs), content_type='image/svg+xml')
 
     def render_to_file(self, filename, **kwargs):
         """Render the graph, and write it to filename"""


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.5/ref/request-response/#django.http.HttpResponse.__init__

>content_type is the MIME type optionally completed by a character set encoding and is used to fill the HTTP Content-Type header. If not specified, it is formed by the DEFAULT_CONTENT_TYPE and DEFAULT_CHARSET settings, by default: “text/html; charset=utf-8”.

>Historically, this parameter was called mimetype (now deprecated)

Thanks to @Irexistus for pointing that out.