### PR TITLE
Support value formatter for pie graphs 

### DIFF
--- a/pygal/graph/pie.py
+++ b/pygal/graph/pie.py
@@ -32,6 +32,15 @@ class Pie(Graph):
     """Pie graph"""
 
     _adapters = [positive, none_to_zero]
+    
+    @property
+    def _format(self):
+        """Return the value formatter for this graph"""
+        def percentage_formatter(y, self=self):
+            total = sum(map(sum, map(lambda x: x.values, self.series)))
+            perc = y/total
+            return '{0:.2%}'.format(perc)
+        return self.value_formatter or percentage_formatter
 
     def slice(self, serie, start_angle, total):
         """Make a serie slice"""
@@ -57,7 +66,7 @@ class Pie(Graph):
             else:
                 angle = 2 * pi * perc
             serie_angle += angle
-            val = '{0:.2%}'.format(perc)
+            val = self._format(val)
             metadata = serie.metadata.get(i)
             slice_ = decorate(
                 self.svg,
@@ -77,7 +86,7 @@ class Pie(Graph):
             total_perc += perc
 
         if dual:
-            val = '{0:.2%}'.format(total_perc)
+            val = self._format(total_perc*total)
             self.svg.slice(serie_node,
                            self.svg.node(slices, class_="big_slice"),
                            radius * .9, 0, serie_angle,

--- a/pygal/svg.py
+++ b/pygal/svg.py
@@ -127,7 +127,9 @@ class Svg(object):
             return dict((k, getattr(self.graph.state, k))
                         for k in dir(self.graph.config)
                         if not k.startswith('_') and not hasattr(
-                                getattr(self.graph.config, k), '__call__'))
+                                getattr(self.graph.config, k), '__call__')
+                                and not hasattr(getattr(self.graph.state, k), '__call__') 
+                                )
 
         def json_default(o):
             if isinstance(o, (datetime, date)):


### PR DESCRIPTION
- Pie graphs do now support a value_formatter as well
Additionally, I needed to change the json dictionary for being able to specify a value_formatter at all:
- fix specifying a value_formatter, needed to be excluded from the json dictionary
