### PR TITLE
New Box plot modes, outliers

### DIFF
--- a/pygal/config.py
+++ b/pygal/config.py
@@ -344,7 +344,8 @@ class Config(CommonConfig):
     mode = Key(
         None, str, "Value", "Sets the mode to be used. "
         "(Currently only supported on box plot)",
-        "May be %s" % ' or '.join(["1.5IQR", "extremes", "tukey"]))
+        "May be %s" % ' or '.join(["1.5IQR", "extremes", "tukey", "stdev",\
+            "pstdev"]))
 
     order_min = Key(
         None, int, "Value", "Minimum order of scale, defaults to None")

--- a/pygal/config.py
+++ b/pygal/config.py
@@ -344,7 +344,7 @@ class Config(CommonConfig):
     mode = Key(
         None, str, "Value", "Sets the mode to be used. "
         "(Currently only supported on box plot)",
-        "May be %s" % ' or '.join(["1.5IQR", "extremes"]))
+        "May be %s" % ' or '.join(["1.5IQR", "extremes", "tukey"]))
 
     order_min = Key(
         None, int, "Value", "Minimum order of scale, defaults to None")

--- a/pygal/graph/box.py
+++ b/pygal/graph/box.py
@@ -99,7 +99,7 @@ class Box(Graph):
 
     @property
     def _len(self):
-        """Len is always 5 here"""
+        """Len is always 7 here"""
         return 7
 
     def _boxf(self, serie):

--- a/pygal/graph/box.py
+++ b/pygal/graph/box.py
@@ -212,8 +212,8 @@ class Box(Graph):
             else:  # seq has an odd length
                 return seq[n // 2]
 
-        # sort the copy in case the originals must stay in original order
         outliers = []
+        # sort the copy in case the originals must stay in original order
         s = sorted([x for x in values if x is not None])
         n = len(s)
         if not n:
@@ -252,8 +252,6 @@ class Box(Graph):
                 q0 = s[b0]
                 q4 = s[b4-1]
                 outliers = s[:b0] + s[b4:]
-                #print "Q: [%s,%s,%s,%s,%s] O: %s" \
-                #        % (q0, q1, q2, q3, q4, outliers)
 
             else:
                 q0 = q1 - 1.5 * iqr

--- a/pygal/graph/box.py
+++ b/pygal/graph/box.py
@@ -55,6 +55,7 @@ class Box(Graph):
                     return 'Min: %s Lower Whisker: %s Q1: %s Q2: %s Q3: %s '\
                         'Upper Whisker: %s Max: %s' % tuple(map(sup, x))
                 else:
+                    # 1.5IQR mode
                     return 'Q1: %s Q2: %s Q3: %s' % tuple(map(sup, x[2:5]))
             else:
                 return sup(x)
@@ -240,6 +241,8 @@ class Box(Graph):
         n = len(s)
         if not n:
             return (0, 0, 0, 0, 0, 0, 0), []
+        elif n == 1:
+            return (s[0], s[0], s[0], s[0], s[0], s[0], s[0]), []
         else:
             q2 = median(s)
             # See 'Method 3' in http://en.wikipedia.org/wiki/Quartile
@@ -277,7 +280,6 @@ class Box(Graph):
             elif mode == 'stdev':
                 # one standard deviation above and below the mean of the data
                 sd = stdev(s)
-                print s, sd
                 b0 = bisect_left(s, q2 - sd)
                 b4 = bisect_right(s, q2 + sd)
                 q0 = s[b0]
@@ -287,13 +289,13 @@ class Box(Graph):
                 # one population standard deviation above and below
                 # the mean of the data
                 sdp = pstdev(s)
-                print s, sd
                 b0 = bisect_left(s, q2 - sdp)
                 b4 = bisect_right(s, q2 + sdp)
                 q0 = s[b0]
                 q4 = s[b4-1]
                 outliers = s[:b0] + s[b4:]
             else:
+                # 1.5IQR mode
                 q0 = q1 - 1.5 * iqr
                 q4 = q3 + 1.5 * iqr
             return (min_s, q0, q1, q2, q3, q4, max_s), outliers

--- a/pygal/test/test_box.py
+++ b/pygal/test/test_box.py
@@ -113,7 +113,7 @@ def test_quartiles_tukey():
     assert max_s == 75
     assert outliers == [75]
 
-    # one more outlier, -30
+    # one more outlier, 77
     c = [6, 7, 15, 36, 39, 40, 41, 42, 43, 47, 49, 75, 77]
     (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(
         c, mode='tukey')
@@ -125,6 +125,18 @@ def test_quartiles_tukey():
     assert 75 in outliers
     assert 77 in outliers
 
+def test_quartiles_stdev():
+    a = [35, 42, 35, 41, 36, 6, 12, 51, 33, 27, 46, 36, 44, 53, 75, 46, 16,\
+        51, 45, 29, 25, 26, 54, 61, 27, 40, 23, 34, 51, 37]
+    SD = 14.67
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(
+        a, mode='stdev')
+    assert min_s == min(a)
+    assert max_s == max(a)
+    assert q2 == 36.5
+    assert q4 <= q2 + SD
+    assert q0 >= q2 - SD
+    assert all(n in outliers for n in [6, 12, 16, 53, 54, 61, 75])
 
 def test_simple_box():
     box = ghostedBox()

--- a/pygal/test/test_box.py
+++ b/pygal/test/test_box.py
@@ -22,7 +22,7 @@ from pygal import Box as ghostedBox
 
 def test_quartiles():
     a = [-2.0, 3.0, 4.0, 5.0, 8.0]  # odd test data
-    q0, q1, q2, q3, q4 = Box._box_points(a)
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(a)
 
     assert q1 == 7.0 / 4.0
     assert q2 == 4.0
@@ -31,17 +31,17 @@ def test_quartiles():
     assert q4 == 23 / 4.0 + 6.0  # q3 + 1.5 * iqr
 
     b = [1.0, 4.0, 6.0, 8.0]  # even test data
-    q0, q1, q2, q3, q4 = Box._box_points(b)
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(b)
 
     assert q2 == 5.0
 
     c = [2.0, None, 4.0, 6.0, None]  # odd with None elements
-    q0, q1, q2, q3, q4 = Box._box_points(c)
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(c)
 
     assert q2 == 4.0
 
     d = [4]
-    q0, q1, q2, q3, q4 = Box._box_points(d)
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(d)
 
     assert q0 == 4
     assert q1 == 4
@@ -49,9 +49,11 @@ def test_quartiles():
     assert q3 == 4
     assert q4 == 4
 
+
 def test_quartiles_min_extremes():
     a = [-2.0, 3.0, 4.0, 5.0, 8.0]  # odd test data
-    q0, q1, q2, q3, q4 = Box._box_points(a, mode='extremes')
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(
+        a, mode='extremes')
 
     assert q1 == 7.0 / 4.0
     assert q2 == 4.0
@@ -60,23 +62,68 @@ def test_quartiles_min_extremes():
     assert q4 == 8.0  # max
 
     b = [1.0, 4.0, 6.0, 8.0]  # even test data
-    q0, q1, q2, q3, q4 = Box._box_points(b, mode='extremes')
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(
+        b, mode='extremes')
 
     assert q2 == 5.0
 
     c = [2.0, None, 4.0, 6.0, None]  # odd with None elements
-    q0, q1, q2, q3, q4 = Box._box_points(c, mode='extremes')
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(
+        c, mode='extremes')
 
     assert q2 == 4.0
 
     d = [4]
-    q0, q1, q2, q3, q4 = Box._box_points(d, mode='extremes')
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(
+        d, mode='extremes')
 
     assert q0 == 4
     assert q1 == 4
     assert q2 == 4
     assert q3 == 4
     assert q4 == 4
+
+
+def test_quartiles_tukey():
+    a = []  # empty data
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(
+        a, mode='tukey')
+    assert min_s == q0 == q1 == q2 == q3 == q4 == 0
+    assert outliers == []
+
+    # https://en.wikipedia.org/wiki/Quartile example 1
+    b = [6, 7, 15, 36, 39, 40, 41, 42, 43, 47, 49]
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(
+        b, mode='tukey')
+    assert min_s == q0 == 6
+    assert q1 == 20.25
+    assert q2 == 40
+    assert q3 == 42.75
+    assert max_s == q4 == 49
+    assert outliers == []
+
+    # previous test with added outlier 75
+    c = [6, 7, 15, 36, 39, 40, 41, 42, 43, 47, 49, 75]
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(
+        c, mode='tukey')
+    assert min_s == q0 == 6
+    assert q1 == 25.5
+    assert q2 == (40 + 41) / 2.0
+    assert q3 == 45
+    assert max_s == 75
+    assert outliers == [75]
+
+    # one more outlier, -30
+    c = [6, 7, 15, 36, 39, 40, 41, 42, 43, 47, 49, 75, 77]
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(
+        c, mode='tukey')
+    assert min_s == q0 == 6
+    assert q1 == 30.75
+    assert q2 == 41
+    assert q3 == 47.5
+    assert max_s == 77
+    assert 75 in outliers
+    assert 77 in outliers
 
 
 def test_simple_box():

--- a/pygal/test/test_box.py
+++ b/pygal/test/test_box.py
@@ -138,6 +138,12 @@ def test_quartiles_stdev():
     assert q0 >= q2 - SD
     assert all(n in outliers for n in [6, 12, 16, 53, 54, 61, 75])
 
+    b = [5] # test for posible zero division
+    (min_s, q0, q1, q2, q3, q4, max_s), outliers = Box._box_points(
+        b, mode='stdev')
+    assert min_s == q0 == q1 == q2 == q3 == q4 == max_s == b[0]
+    assert outliers == []
+
 def test_simple_box():
     box = ghostedBox()
     box.add('test1', [-1, 2, 3, 3.1, 3.2, 4, 5])


### PR DESCRIPTION
Added several new modes for counting whiskers/inner fences in box plot. Inspired by https://en.wikipedia.org/wiki/Box_plot. Outliers are plotted as circles if there are some.

* `tukey` - implements J. W. Tukey version of box plot

 > the lowest datum still within 1.5 IQR of the lower quartile, and the highest datum still within 1.5 IQR of the upper quartile

* `stdev` - whiskers are within sample standard deviation of data

 > one standard deviation above and below the mean of the data

* `pstdev` - as above, but population standard deviation formula is used

Note: previously existing, but not documented mode

* `extremes` - whiskers are set to min and max data value

Implements #121, #149 

Example:
```python
import pygal

box_plot = pygal.Box(mode='tukey', tooltip_font_size=9)
box_plot.title = 'V8 benchmark results'
box_plot.add('Chrome', [6395, 8212, 7520, 7218, 12464, 1660, 2123, 8607])
box_plot.add('Firefox', [7473, 8099, 11700, 2651, 6361, 1044, 3797, 9450])
box_plot.add('Opera', [3472, 2933, 4203, 5229, 5810, 1828, 9013, 4669])
box_plot.add('IE', [43, 41, 59, 79, 144, 136, 34, 102])
box_plot.render()
box_plot.render_to_file('box-plot.svg')
```
![image](https://cloud.githubusercontent.com/assets/1554161/8150038/2a54cee8-12da-11e5-9aaf-741c368f110e.png)
