### PR TITLE
Display values on top of every bar chart. Fix #214

### DIFF
--- a/pygal/config.py
+++ b/pygal/config.py
@@ -434,6 +434,7 @@ class Config(CommonConfig):
         "Don't prefix css")
 
     inverse_y_axis = Key(False, bool, "Misc", "Inverse Y axis direction")
+    
     show_data_labels = Key(
         False, bool, "Label", "Set to false to hide data-labels")
 

--- a/pygal/config.py
+++ b/pygal/config.py
@@ -434,6 +434,8 @@ class Config(CommonConfig):
         "Don't prefix css")
 
     inverse_y_axis = Key(False, bool, "Misc", "Inverse Y axis direction")
+    show_data_labels = Key(
+        False, bool, "Label", "Set to false to hide data-labels")
 
 
 class SerieConfig(CommonConfig):

--- a/pygal/graph/bar.py
+++ b/pygal/graph/bar.py
@@ -86,6 +86,9 @@ class Bar(Graph):
                 bar, val, x_center, y_center, classes="centered")
             self._static_value(serie_node, val, x_center, y_center)
 
+            if self.show_data_labels:
+                self._add_data_label(serie, bar, val, x, y, self.zero)
+                
     def _compute(self):
         if self._min:
             self._box.ymin = min(self._min, self.zero)
@@ -135,3 +138,18 @@ class Bar(Graph):
             self.bar(serie)
         for serie in self.secondary_series:
             self.bar(serie, True)
+
+    def _add_data_label(self, serie, node, value, x, y, zero):
+        width = (self.view.x(1) - self.view.x(0)) / self._len
+        x, y = self.view((x, y))
+        series_margin = width * self._series_margin
+        x += series_margin
+        width -= 2 * series_margin
+        width /= self._order
+        x += serie.index * width
+        serie_margin = width * self._serie_margin
+        x += serie_margin
+        width -= 2 * serie_margin
+        height = self.view.y(zero) - y
+
+        self.svg.node(node,'text',x=x + width / 2,y=y-2,class_="text").text = value


### PR DESCRIPTION
Update config.py add Key show_data_labels.
Update bar.py add function _add_data_label.

when setting show_data_labels=True before render() is called. The renderred graph will display data labels on the top of each bar 

import pygal
bar_chart = pygal.Bar()
bar_chart.add('Fibonacci', [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55])
bar_chart.add('Padovan', [1, 1, 1, 2, 2, 3, 4, 5, 7, 9, 12])
bar_chart.show_data_labels=True
bar_chart.render()

![pygal](https://cloud.githubusercontent.com/assets/11566020/8328256/b87973da-1aa1-11e5-90b2-e1b90dba1313.png)

