### PR TITLE
New style options for guide line stroke-dasharray

### DIFF
--- a/pygal/css/graph.css
+++ b/pygal/css/graph.css
@@ -54,11 +54,11 @@
 }
 
 {{ id }}.axis .guide.line {
-  stroke-dasharray: 4,4;
+  stroke-dasharray: {{ style.guide_stroke_dasharray }};
 }
 
 {{ id }}.axis .major.guide.line {
-  stroke-dasharray: 6,6;
+  stroke-dasharray: {{ style.major_guide_stroke_dasharray }};
 }
 
 {{ id }}.horizontal .axis.y .guide.line,

--- a/pygal/style.py
+++ b/pygal/style.py
@@ -33,6 +33,7 @@ class Style(object):
     foreground = 'rgba(0, 0, 0, .87)'
     foreground_strong = 'rgba(0, 0, 0, 1)'
     foreground_subtle = 'rgba(0, 0, 0, .54)'
+
     # Monospaced font is highly encouraged
     font_family = 'Consolas, "Liberation Mono", Menlo, Courier, '
     'monospace'
@@ -53,6 +54,9 @@ class Style(object):
     legend_font_size = 14
     no_data_font_size = 64
 
+    # Guide line stroke style
+    guide_stroke_dasharray = '4,4'
+    major_guide_stroke_dasharray = '6,6'
 
     opacity = '.7'
     opacity_hover = '.8'


### PR DESCRIPTION
Problem:
Redefining stroke-dasharray with a custom css doesn't work well sometimes (even with !important).

Solution:
Added options guide_stroke_dasharray and major_guide_stroke_dasharray to Style Class.
Changed graph.css to respect guide_stroke_dasharray and major_guide_stroke_dasharray.