### PR TITLE
Fixing to checks breaking rendering of DateTimeLine and TimeDeltaLine

### DIFF
--- a/pygal/graph/xy.py
+++ b/pygal/graph/xy.py
@@ -122,8 +122,9 @@ class XY(Line, Dual):
             else:
                 xrng = None
 
-        if xrng:
+        # these values can also be 0 (zero), so testing explicitly for None
+        if xrng is not None:
             self._box.xmin, self._box.xmax = xmin, xmax
 
-        if yrng:
+        if yrng is not None:
             self._box.ymin, self._box.ymax = ymin, ymax


### PR DESCRIPTION
The two checks for range of x and y values did not test for None. These values can also be zero and therefore the check evaluates to False, which then leads to empty rendered SVG and PNG graphs.

I could not find tests actually validating SVG graphs, so the current tests do not cover this. Feel free to point out, where this is and I update the tests.