### PR TITLE
Fix unparse_color for python 3.5+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
   # - pypy Disabled for pypy < 2.6.0
 
 install:

--- a/pygal/colors.py
+++ b/pygal/colors.py
@@ -126,19 +126,20 @@ def unparse_color(r, g, b, a, type):
     if type == '#rgb':
         # Don't lose precision on rgb shortcut
         if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
-            return '#%x%x%x' % (r / 17, g / 17, b / 17)
+            return '#%x%x%x' % (int(r / 17), int(g / 17), int(b / 17))
         type = '#rrggbb'
 
     if type == '#rgba':
         if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
-            return '#%x%x%x%x' % (r / 17, g / 17, b / 17, a * 15)
+            return '#%x%x%x%x' % (int(r / 17), int(g / 17), int(b / 17),
+                                  int(a * 15))
         type = '#rrggbbaa'
 
     if type == '#rrggbb':
         return '#%02x%02x%02x' % (r, g, b)
 
     if type == '#rrggbbaa':
-        return '#%02x%02x%02x%02x' % (r, g, b, a * 255)
+        return '#%02x%02x%02x%02x' % (r, g, b, int(a * 255))
 
     if type == 'rgb':
         return 'rgb(%d, %d, %d)' % (r, g, b)


### PR DESCRIPTION
Since Python 3.5.0, "%x" doesn't accept float anymore, and the related tests are broken. Explicitly converting it to int fixes all tests here.

Test failures:

```
=================================== FAILURES ===================================
___________________________ test_unparse_color[lxml] ___________________________

    def test_unparse_color():
        """Test color unparse function"""
>       assert unparse_color(17, 34, 51, 1., '#rgb') == '#123'

pygal/test/test_colors.py:45:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 17, g = 34, b = 51, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
__________________________ test_unparse_color[etree] ___________________________

    def test_unparse_color():
        """Test color unparse function"""
>       assert unparse_color(17, 34, 51, 1., '#rgb') == '#123'

pygal/test/test_colors.py:45:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 17, g = 34, b = 51, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
______________________________ test_darken[lxml] _______________________________

    def test_darken():
        """Test darken color function"""
>       assert darken('#800', 20) == '#200'

pygal/test/test_colors.py:59:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pygal/colors.py:200: in darken
    return adjust(color, 2, -percent)
pygal/colors.py:175: in adjust
    return unparse_color(r, g, b, a, type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 34, g = 0, b = 0, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
______________________________ test_darken[etree] ______________________________

    def test_darken():
        """Test darken color function"""
>       assert darken('#800', 20) == '#200'

pygal/test/test_colors.py:59:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pygal/colors.py:200: in darken
    return adjust(color, 2, -percent)
pygal/colors.py:175: in adjust
    return unparse_color(r, g, b, a, type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 34, g = 0, b = 0, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
______________________________ test_lighten[lxml] ______________________________

    def test_lighten():
        """Test lighten color function"""
>       assert lighten('#800', 20) == '#e00'

pygal/test/test_colors.py:76:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pygal/colors.py:195: in lighten
    return adjust(color, 2, percent)
pygal/colors.py:175: in adjust
    return unparse_color(r, g, b, a, type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 238, g = 0, b = 0, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
_____________________________ test_lighten[etree] ______________________________

    def test_lighten():
        """Test lighten color function"""
>       assert lighten('#800', 20) == '#e00'

pygal/test/test_colors.py:76:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pygal/colors.py:195: in lighten
    return adjust(color, 2, percent)
pygal/colors.py:175: in adjust
    return unparse_color(r, g, b, a, type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 238, g = 0, b = 0, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
_____________________________ test_saturate[lxml] ______________________________

    def test_saturate():
        """Test color saturation function"""
>       assert saturate('#000', 20) == '#000'

pygal/test/test_colors.py:88:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pygal/colors.py:185: in saturate
    return adjust(color, 1, percent)
pygal/colors.py:175: in adjust
    return unparse_color(r, g, b, a, type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 0, g = 0, b = 0, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
_____________________________ test_saturate[etree] _____________________________

    def test_saturate():
        """Test color saturation function"""
>       assert saturate('#000', 20) == '#000'

pygal/test/test_colors.py:88:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pygal/colors.py:185: in saturate
    return adjust(color, 1, percent)
pygal/colors.py:175: in adjust
    return unparse_color(r, g, b, a, type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 0, g = 0, b = 0, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
____________________________ test_desaturate[lxml] _____________________________

    def test_desaturate():
        """Test color desaturation function"""
>       assert desaturate('#000', 20) == '#000'

pygal/test/test_colors.py:96:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pygal/colors.py:190: in desaturate
    return adjust(color, 1, -percent)
pygal/colors.py:175: in adjust
    return unparse_color(r, g, b, a, type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 0, g = 0, b = 0, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
____________________________ test_desaturate[etree] ____________________________

    def test_desaturate():
        """Test color desaturation function"""
>       assert desaturate('#000', 20) == '#000'

pygal/test/test_colors.py:96:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pygal/colors.py:190: in desaturate
    return adjust(color, 1, -percent)
pygal/colors.py:175: in adjust
    return unparse_color(r, g, b, a, type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 0, g = 0, b = 0, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
______________________________ test_rotate[lxml] _______________________________

    def test_rotate():
        """Test color rotation function"""
>       assert rotate('#000', 45) == '#000'

pygal/test/test_colors.py:104:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pygal/colors.py:180: in rotate
    return adjust(color, 0, percent)
pygal/colors.py:175: in adjust
    return unparse_color(r, g, b, a, type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 0, g = 0, b = 0, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
______________________________ test_rotate[etree] ______________________________

    def test_rotate():
        """Test color rotation function"""
>       assert rotate('#000', 45) == '#000'

pygal/test/test_colors.py:104:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pygal/colors.py:180: in rotate
    return adjust(color, 0, percent)
pygal/colors.py:175: in adjust
    return unparse_color(r, g, b, a, type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

r = 0, g = 0, b = 0, a = 1.0, type = '#rgb'

    def unparse_color(r, g, b, a, type):
        """
        Take the r, g, b, a color values and give back
        a type css color string. This is the inverse function of parse_color
        """
        if type == '#rgb':
            # Don't lose precision on rgb shortcut
            if r % 17 == 0 and g % 17 == 0 and b % 17 == 0:
>               return '#%x%x%x' % (r / 17, g / 17, b / 17)
E               TypeError: %x format: an integer is required, not float

pygal/colors.py:129: TypeError
=================== 12 failed, 3746 passed in 50.63 seconds ====================
```