### PR TITLE
Fix the dead installing link in first_step.rst

### DIFF
--- a/docs/documentation/first_steps.rst
+++ b/docs/documentation/first_steps.rst
@@ -3,7 +3,7 @@ First steps
 
 .. caution::
 
-  First you need to install pygal, see `installing <.//installing.html>`_.
+  First you need to install pygal, see `installing <../installing.html>`_.
 
 When it's done, you are ready to make your first chart:
 


### PR DESCRIPTION
The current install link in the [first steps](http://www.pygal.org/en/latest/documentation/first_steps.html) page  is wrong, this PR should fix this problem.