### PR TITLE
Added option to put value label on bottom, top or middle.

### DIFF
--- a/pygal/config.py
+++ b/pygal/config.py
@@ -448,6 +448,10 @@ class Config(CommonConfig):
         "Set the ordinate zero value",
         "Useful for filling to another base than abscissa")
 
+    position_values = Key(
+        None, str,
+        "Text", "In bar charts, print values on 'middle', 'top' or 'bottom' of the bar")
+
     # Text #
     no_data_text = Key(
         "No data", str, "Text", "Text to display when no data is given")

--- a/pygal/css/graph.css
+++ b/pygal/css/graph.css
@@ -22,6 +22,10 @@
   text-anchor: middle;
 }
 
+{{ id }}.centered {
+  text-anchor: {{ style.align }};
+}
+
 {{ id }}.guide.line {
   fill: none;
 }

--- a/pygal/css/graph.css
+++ b/pygal/css/graph.css
@@ -22,7 +22,6 @@
   text-anchor: middle;
 }
 
-
 {{ id }}.centered {
   text-anchor: {{ style.align }};
 }

--- a/pygal/css/graph.css
+++ b/pygal/css/graph.css
@@ -22,6 +22,7 @@
   text-anchor: middle;
 }
 
+
 {{ id }}.centered {
   text-anchor: {{ style.align }};
 }

--- a/pygal/graph/bar.py
+++ b/pygal/graph/bar.py
@@ -64,6 +64,29 @@ class Bar(Graph):
             x=x, y=y, rx=r, ry=r, width=width, height=height,
             class_='rect reactive tooltip-trigger'), serie.metadata.get(i))
         transpose = swap if self.horizontal else ident
+        if not self.horizontal:
+            if self.config.position_values == 'top':
+                self.print_values = True
+                return transpose((x + width / 2, y - (
+                    3 if not self.config.inverse_y_axis else -self.svg.graph.style.value_font_size)))
+            if self.config.position_values == 'bottom':
+                self.print_values = True
+                return transpose((x + width / 2, self.view.y(zero) - (
+                    3 if not self.config.inverse_y_axis else -self.svg.graph.style.value_font_size)))
+        else:
+            if self.config.position_values == 'top':
+                self.print_values = True
+                self.svg.graph.style.align = 'left'
+                return transpose((x + width / 2 + self.svg.graph.style.value_font_size / 3,
+                                  y + 3))
+            if self.config.position_values == 'bottom':
+                self.print_values = True
+                self.svg.graph.style.align = 'left'
+                return transpose((x + width / 2 + self.svg.graph.style.value_font_size / 3,
+                                  self.view.y(zero) + 3))
+
+        if self.config.position_values == 'middle':
+            self.print_values = True
         return transpose((x + width / 2, y + height / 2))
 
     def bar(self, serie, rescale=False):
@@ -86,12 +109,13 @@ class Bar(Graph):
                 metadata)
             val = self._format(serie.values[i])
 
-            x_center, y_center = self._bar(
+            _x, _y = self._bar(
                 serie, bar, x, y, i, self.zero, secondary=rescale)
             self._tooltip_data(
-                bar, val, x_center, y_center, "centered",
+                bar, val, _x, _y, "centered",
                 self._get_x_label(i))
-            self._static_value(serie_node, val, x_center, y_center, metadata)
+            self._static_value(
+                serie_node, val, _x, _y, metadata)
 
     def _compute(self):
         """Compute y min and max and y scale and set labels"""

--- a/pygal/graph/bar.py
+++ b/pygal/graph/bar.py
@@ -64,26 +64,22 @@ class Bar(Graph):
             x=x, y=y, rx=r, ry=r, width=width, height=height,
             class_='rect reactive tooltip-trigger'), serie.metadata.get(i))
         transpose = swap if self.horizontal else ident
-        if not self.horizontal:
-            if self.config.position_values == 'top':
-                self.print_values = True
-                return transpose((x + width / 2, y - (
-                    3 if not self.config.inverse_y_axis else -self.svg.graph.style.value_font_size)))
-            if self.config.position_values == 'bottom':
-                self.print_values = True
-                return transpose((x + width / 2, self.view.y(zero) - (
-                    3 if not self.config.inverse_y_axis else -self.svg.graph.style.value_font_size)))
-        else:
-            if self.config.position_values == 'top':
-                self.print_values = True
+        if self.config.position_values == 'top':
+            self.print_values = True
+            if self.horizontal:
                 self.svg.graph.style.align = 'left'
                 return transpose((x + width / 2 + self.svg.graph.style.value_font_size / 3,
                                   y + 3))
-            if self.config.position_values == 'bottom':
-                self.print_values = True
+            return transpose((x + width / 2, y - (
+                3 if not self.config.inverse_y_axis else -self.svg.graph.style.value_font_size)))
+        if self.config.position_values == 'bottom':
+            self.print_values = True
+            if self.horizontal:
                 self.svg.graph.style.align = 'left'
                 return transpose((x + width / 2 + self.svg.graph.style.value_font_size / 3,
                                   self.view.y(zero) + 3))
+            return transpose((x + width / 2, self.view.y(zero) - (
+                3 if not self.config.inverse_y_axis else -self.svg.graph.style.value_font_size)))
 
         if self.config.position_values == 'middle':
             self.print_values = True

--- a/pygal/style.py
+++ b/pygal/style.py
@@ -62,6 +62,9 @@ class Style(object):
     guide_stroke_dasharray = '4,4'
     major_guide_stroke_dasharray = '6,6'
 
+    # Align value labels in bar charts
+    align = 'middle'
+
     opacity = '.7'
     opacity_hover = '.8'
     transition = '150ms'

--- a/pygal/style.py
+++ b/pygal/style.py
@@ -62,6 +62,7 @@ class Style(object):
     guide_stroke_dasharray = '4,4'
     major_guide_stroke_dasharray = '6,6'
 
+
     # Align value labels in bar charts
     align = 'middle'
 

--- a/pygal/util.py
+++ b/pygal/util.py
@@ -144,6 +144,7 @@ def compute_logarithmic_scale(min_, max_, min_scale, max_scale):
     """Compute an optimal scale for logarithmic"""
     if max_ <= 0 or min_ <= 0:
         return []
+    max_ **= 2
     min_order = int(floor(log10(min_)))
     max_order = int(ceil(log10(max_)))
     positions = []
@@ -172,6 +173,7 @@ def compute_scale(
         return [0]
     if max_ - min_ == 0:
         return [min_]
+    max_ *= 1.1
     if logarithmic:
         log_scale = compute_logarithmic_scale(
             min_, max_, min_scale, max_scale)
@@ -193,7 +195,7 @@ def compute_scale(
     position = round_to_scale(min_, step)
     while position < (max_ + step):
         rounded = round_to_scale(position, step)
-        if min_ <= rounded <= max_:
+        if min_ <= rounded <= max_+step:
             if rounded not in positions:
                 positions.append(rounded)
         position += step

--- a/pygal/view.py
+++ b/pygal/view.py
@@ -50,7 +50,9 @@ class Box(object):
 
     """Chart boundings"""
 
-    margin = .02
+    pos_margin = 0.1
+    neg_margin = 0.02
+    x_margin = 0.02
 
     def __init__(self, xmin=0, ymin=0, xmax=1, ymax=1):
         """
@@ -137,13 +139,14 @@ class Box(object):
         if not self.height:
             self.ymin /= 2
             self.ymax += self.ymin
-        xmargin = self.margin * self.width
+        xmargin = self.x_margin * self.width
         self.xmin -= xmargin
         self.xmax += xmargin
         if with_margin:
-            ymargin = self.margin * self.height
-            self.ymin -= ymargin
-            self.ymax += ymargin
+            neg_margin = self.neg_margin * self.height
+            pos_margin = self.pos_margin * self.height
+            self.ymin -= neg_margin
+            self.ymax += pos_margin
 
 
 class View(object):
@@ -334,6 +337,7 @@ class LogView(View):
         self.width = width
         self.height = height
         self.box = box
+        self.box.ymax *= 2
         self.log10_ymax = log10(self.box.ymax) if self.box.ymax > 0 else 0
         self.log10_ymin = log10(self.box.ymin) if self.box.ymin > 0 else 0
         if self.log10_ymin == self.log10_ymax:
@@ -399,6 +403,7 @@ class HorizontalLogView(XLogView):
         self.width = width
         self.height = height
         self.box = box
+        self.box.ymax **= 1.1
         self.log10_xmax = log10(self.box.ymax) if self.box.ymax > 0 else 0
         self.log10_xmin = log10(self.box.ymin) if self.box.ymin > 0 else 0
         if self.log10_xmin == self.log10_xmax:


### PR DESCRIPTION
When creating a bar chart you have an additional option called "position_values" that can hold the values 'top', 'bottom' or 'middle'. Either one of those values will force print_values to be True.

Example "top":
chart = pygal.Bar(position_values='top')
chart.add('Series 1', [121, 63, 54, 67, 89])
chart.render()

![image](https://cloud.githubusercontent.com/assets/13579256/12043233/2f038f66-ae51-11e5-97af-794cae0d15a7.png)

Example "bottom":
chart = pygal.Bar(position_values='bottom')
chart.add('Series 1', [121, 63, 54, 67, 89])
chart.render()

![image](https://cloud.githubusercontent.com/assets/13579256/12043247/58b8360e-ae51-11e5-9053-06698f0d9d82.png)

Feature works with HorizontalBar and Bar, it also works with inverse_y=True as well as logarithmic = True