### PR TITLE
Added confidence intervals to line charts and bar charts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - pip install pyquery
   - pip install cairosvg
   - pip install coveralls
+  - pip install numpy
   - pip install scipy
 
 script: py.test pygal/ --flake8 --cov-report= --cov=pygal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+python:
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  # - pypy Disabled for pypy < 2.6.0
+
+install:
+  - pip install .
+  - pip install pygal_maps_world
+  - pip install pygal_maps_fr
+  - pip install pygal_maps_ch
+  - pip install pytest
+  - pip install pytest-flake8
+  - pip install pytest-cov
+  - pip install lxml
+  - pip install pyquery
+  - pip install cairosvg
+  - pip install coveralls
+  - pip install scipy
+
+script: py.test pygal/ --flake8 --cov-report= --cov=pygal
+
+after_success: coveralls
+
+sudo: false

--- a/pygal/config.py
+++ b/pygal/config.py
@@ -441,11 +441,6 @@ class Config(CommonConfig):
         "Level of significance",
         "Level of significance for your chart, default is 95% confidence interval.")
 
-    CI_std = Key(
-        None, float, "Confidence Interval",
-        "Standard deviation of data",
-        "Standard deviation of data")
-
 
 class SerieConfig(CommonConfig):
     """Class holding serie config values"""

--- a/pygal/graph/bar.py
+++ b/pygal/graph/bar.py
@@ -72,22 +72,9 @@ class Bar(Graph):
                 continue
             metadata = serie.metadata.get(i)
             self.svg.node(ci, class_='interval')
-            try:
-                _T, _B, _L, _R, _C = self._compute_confidence_interval(self._CI_x, self._CI_y, serie.values[i], metadata)
-                if self.horizontal:
-                    _order = (_T, _R, _T, _L, _T, _C, _B, _C, _B, _L, _B, _R)
-                else:
-                    _order = (_R, _T, _L, _T, _C, _T, _C, _B, _L, _B, _R, _B)
-                self.svg.node(
-                    parent=serie_node['plot'],
-                    tag='polyline',
-                    attrib={
-                        'fill': None,
-                        'stroke': '#095668',
-                        'points': '%s,%s %s,%s %s,%s %s,%s %s,%s %s,%s' % _order})
-            except (KeyError):
-                pass
-
+            ci_points = self._compute_confidence_interval(self._CI_x, self._CI_y, serie.values[i], metadata)
+            self.svg.node(parent=serie_node['plot'], tag='polyline',
+                          attrib={'fill': None, 'stroke': '#095668', 'points': ci_points})
             bar = decorate(
                 self.svg,
                 self.svg.node(bars, class_='bar'),

--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -598,6 +598,8 @@ class Graph(BaseGraph):
             self._y_title_height = height + self.spacing
 
     def _compute_confidence_interval(self, x, y, val, metadata):
+        if metadata is None:
+            return
         if self.horizontal:
             x, y = y, x
         ci_width = self.view.width / 100

--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -602,6 +602,8 @@ class Graph(BaseGraph):
             x, y = y, x
         ci_width = self.view.width / 100
         if self.CI_proportion:
+            if 'base' not in metadata.keys():
+                return
             self._alpha = stats.norm.ppf(
                     self.config.CI_confidence + (1 - self.config.CI_confidence) / 2
                 )
@@ -613,8 +615,9 @@ class Graph(BaseGraph):
             _R = x+ci_width # right width of line
             _L = x-ci_width # left width of line
             _C = x
-            return _T, _B, _L, _R, _C
         else:
+            if 'base' not in metadata.keys() or 'std' not in metadata.keys():
+                return
             self._alpha = stats.t.ppf(
                 self.config.CI_confidence + (1 - self.config.CI_confidence) / 2,
                 metadata['base']-1
@@ -626,7 +629,12 @@ class Graph(BaseGraph):
             _R = x+ci_width
             _L = x-ci_width
             _C = x
-            return _T, _B, _L, _R, _C
+        if self.horizontal:
+            _order = (_T, _R, _T, _L, _T, _C, _B, _C, _B, _L, _B, _R)
+        else:
+            _order = (_R, _T, _L, _T, _C, _T, _C, _B, _L, _B, _R, _B)
+        return '%s,%s %s,%s %s,%s %s,%s %s,%s %s,%s' % _order
+
 
     @cached_property
     def _legends(self):

--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -30,6 +30,7 @@ from pygal.util import (
     truncate, reverse_text_len, get_text_box, get_texts_box, cut, rad,
     decorate)
 from math import sqrt, ceil, cos, sin
+from scipy import stats
 from itertools import repeat, chain
 
 

--- a/pygal/graph/line.py
+++ b/pygal/graph/line.py
@@ -100,17 +100,9 @@ class Line(Graph):
 
                 metadata = serie.metadata.get(i)
                 interval = self.svg.node(ci, class_='interval')
-                try:
-                    _T, _B, _L, _R, _C = self._compute_confidence_interval(x, y, serie.values[i], metadata)
-                    self.svg.node(
-                        parent=interval,
-                        tag='polyline',
-                        attrib={
-                            'fill': None,
-                            'stroke': '#095668',
-                            'points': '%s,%s %s,%s %s,%s %s,%s %s,%s %s,%s' % (_R, _T, _L, _T, _C, _T, _C, _B, _L, _B, _R, _B)})
-                except KeyError:
-                    pass
+                ci_points = self._compute_confidence_interval(x, y, serie.values[i], metadata)
+                self.svg.node(parent=interval, tag='polyline',
+                              attrib={'fill': None, 'stroke': '#095668', 'points': ci_points})
                 classes = []
                 if x > self.view.width / 2:
                     classes.append('left')

--- a/pygal/graph/line.py
+++ b/pygal/graph/line.py
@@ -83,6 +83,7 @@ class Line(Graph):
     def line(self, serie, rescale=False):
         """Draw the line serie"""
         serie_node = self.svg.serie(serie)
+        ci = self.svg.node(serie_node['plot'], class_="ci")
         if rescale and self.secondary_series:
             points = self._rescale(serie.points)
         else:

--- a/pygal/graph/line.py
+++ b/pygal/graph/line.py
@@ -98,6 +98,18 @@ class Line(Graph):
                     continue
 
                 metadata = serie.metadata.get(i)
+                interval = self.svg.node(ci, class_='interval')
+                try:
+                    _T, _B, _L, _R, _C = self._compute_confidence_interval(x, y, serie.values[i], metadata)
+                    self.svg.node(
+                        parent=interval,
+                        tag='polyline',
+                        attrib={
+                            'fill': None,
+                            'stroke': '#095668',
+                            'points': '%s,%s %s,%s %s,%s %s,%s %s,%s %s,%s' % (_R, _T, _L, _T, _C, _T, _C, _B, _L, _B, _R, _B)})
+                except KeyError:
+                    pass
                 classes = []
                 if x > self.view.width / 2:
                     classes.append('left')


### PR DESCRIPTION
I thought I'd share with you that I added confidence intervals to line charts and bar charts. There are two new options. CI_proportion (bool) is default to True, the default behavior is to calculate confidence intervals for proportions (z-test), if set to False it will calculate confidence intervals for means (t-test). CI_confidence (float) is defaulted to 0.95 which means that you will get a confidence interval of 95 % confidence. 

Below is a line chart for proportions (in order to do the calculation you need to provide a base (N)):
chart = pygal.Line()
    chart.CI_proportion = True
    chart.add('Series 1', [
        {'value': 88, 'base': 245},
        {'value': 73, 'base': 125},
        {'value': 54, 'base': 380},
        {'value': 67, 'base': 201},
        {'value': 61, 'base': 245}
    ])
![image](https://cloud.githubusercontent.com/assets/13579256/12060426/c1050c7c-af3d-11e5-8359-ad016bbe1a4c.png)

Here is one for means, which needs the standard deviation as well:
chart = pygal.Line()
    chart.CI_proportion = False
    chart.add('Series 1', [
        {'value': 88, 'base': 245, 'std': 14.3},
        {'value': 73, 'base': 125, 'std': 5.33},
        {'value': 54, 'base': 380, 'std': 2.3},
        {'value': 67, 'base': 201, 'std': 7.79},
        {'value': 61, 'base': 245, 'std': 24.31}
    ])
![image](https://cloud.githubusercontent.com/assets/13579256/12060446/0d49a430-af3e-11e5-8387-e24251cc9dd4.png)
