### PR TITLE
Update output.rst

### DIFF
--- a/docs/documentation/output.rst
+++ b/docs/documentation/output.rst
@@ -52,6 +52,8 @@ With cairosvg installed you can directly get the png file using ``render_to_png`
    ...
    chart.render_to_png('/tmp/chart.png')  # Write the chart in the specified file
 
+In case of rendered image turning up black, installing lxml, tinycss and cssselect should fix the issue.
+
 
 Etree
 -----


### PR DESCRIPTION
render_to_png() generates totally black PNG files for some people. This was discussed on Stack Overflow (https://stackoverflow.com/questions/24476029/pygal-rendering-png-svg-black-pictures/25360101#25360101). The proposed solution (tested) is being added to the PNG section of this page.