### PR TITLE
support for interruptable plots

### DIFF
--- a/docs/documentation/types/line.rst
+++ b/docs/documentation/types/line.rst
@@ -16,6 +16,20 @@ Basic simple line graph:
   line_chart.add('IE',      [85.8, 84.6, 84.7, 74.5,   66, 58.6, 54.7, 44.8, 36.2, 26.6, 20.1])
   line_chart.add('Others',  [14.2, 15.4, 15.3,  8.9,    9, 10.4,  8.9,  5.8,  6.7,  6.8,  7.5])
 
+
+ Interruptions
+ ^^^^^^^^^^^^^
+
+ If you happen to want a break in the middle of a plot, you can pass None values. Additionally,
+ you will need to specify allow_interruptions=True in the constructor, in order for the behaviour
+ to be supported correctly
+
+ .. pygal-code::
+
+   interrupted_chart = pygal.Line(allow_interruptions=True)
+   interrupted_chart.add('Temperature', [22, 34, 43, 12, None, 12, 55, None, 56])
+
+
 Stacked
 ~~~~~~~
 

--- a/docs/documentation/types/xy.rst
+++ b/docs/documentation/types/xy.rst
@@ -63,6 +63,9 @@ DateTime
 Date
 ++++
 
+If you want to plot date/time-series with breaks inside the plot, pass allow_interruptions=True to
+the constructor. See Line on how to do it
+
 .. pygal-code::
 
   from datetime import date

--- a/pygal/graph/line.py
+++ b/pygal/graph/line.py
@@ -158,7 +158,7 @@ class Line(Graph):
                     elif y is None:       # just discard
                         continue
                     else:
-                        cur_sequence.append((x,y))   # append the element
+                        cur_sequence.append((x, y))   # append the element
 
                 if len(cur_sequence) > 0:      # emit last possible sequence
                     sequences.append(cur_sequence)

--- a/pygal/graph/line.py
+++ b/pygal/graph/line.py
@@ -144,21 +144,23 @@ class Line(Graph):
                 view_values = self._fill(view_values)
 
             if self.allow_interruptions:
-                # view_values are in form [(x1, y1), (x2, y2)]. We need to split that
-                # into multiple sequences if a None is present here
+                # view_values are in form [(x1, y1), (x2, y2)]. We
+                # need to split that into multiple sequences if a
+                # None is present here
 
                 sequences = []
                 cur_sequence = []
                 for x, y in view_values:
-                    if y is None and len(cur_sequence) > 0:     # emit current subsequence
+                    if y is None and len(cur_sequence) > 0:
+                        # emit current subsequence
                         sequences.append(cur_sequence)
                         cur_sequence = []
-                    elif y is None:                             # just discard
+                    elif y is None:       # just discard
                         continue
                     else:
-                        cur_sequence.append((x,y))              # append the element
+                        cur_sequence.append((x,y))   # append the element
 
-                if len(cur_sequence) > 0:           # emit last possible sequence
+                if len(cur_sequence) > 0:      # emit last possible sequence
                     sequences.append(cur_sequence)
             else:
                 # plain vanilla rendering
@@ -167,7 +169,8 @@ class Line(Graph):
             for seq in sequences:
                 self.svg.line(
                     serie_node['plot'], seq, close=self._self_close,
-                    class_='line reactive' + (' nofill' if not serie.fill else ''))
+                    class_='line reactive' +
+                           (' nofill' if not serie.fill else ''))
 
     def _compute(self):
         """Compute y min and max and y scale and set labels"""


### PR DESCRIPTION
Pygal is great, and fully runs on PyPy too! Matplotlib sure can't do that.

However, it has a singular problem for me - Nones inside data are simply ignored, instead of being meaningful. Consider a time series plot - if it has a None inside, lines should not connect dots. The line should be interrupted.
Given
```python
  interrupted_chart.add('Temperature', [22, 34, 43, 12, None, 12, 55, None, 56])
```
 Result should look rather like
![image](https://cloud.githubusercontent.com/assets/103189/12594098/979c35c6-c474-11e5-9b7f-7d1249db8216.png)

And certainly not 
![image](https://cloud.githubusercontent.com/assets/103189/12594163/f4cedb90-c474-11e5-8cdf-da544b39a1cf.png)

Which is how it looks now.

I have added support for this kinds of plot. The only thing user needs to do, is include *allow_interruptions=True* in plot constructor, like:
```python
  interrupted_chart = pygal.XY(allow_interruptions=True)
```

It works for most kinds of plot (time series included) as it patches the Line class.
