### PR TITLE
Added options for Horizontal Line charts

### DIFF
--- a/pygal/__init__.py
+++ b/pygal/__init__.py
@@ -40,6 +40,7 @@ from pygal.graph.histogram import Histogram
 from pygal.graph.horizontalbar import HorizontalBar
 from pygal.graph.horizontalstackedbar import HorizontalStackedBar
 from pygal.graph.line import Line
+from pygal.graph.horizontalline import HorizontalLine
 from pygal.graph.pie import Pie
 from pygal.graph.pyramid import Pyramid, VerticalPyramid
 from pygal.graph.radar import Radar

--- a/pygal/__init__.py
+++ b/pygal/__init__.py
@@ -41,6 +41,7 @@ from pygal.graph.horizontalbar import HorizontalBar
 from pygal.graph.horizontalstackedbar import HorizontalStackedBar
 from pygal.graph.line import Line
 from pygal.graph.horizontalline import HorizontalLine
+from pygal.graph.horizontalstackedline import HorizontalStackedLine
 from pygal.graph.pie import Pie
 from pygal.graph.pyramid import Pyramid, VerticalPyramid
 from pygal.graph.radar import Radar

--- a/pygal/graph/horizontalline.py
+++ b/pygal/graph/horizontalline.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# This file is part of pygal
+#
+# A python svg graph plotting library
+# Copyright © 2012-2015 Kozea
+#
+# This library is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with pygal. If not, see <http://www.gnu.org/licenses/>.
+
+"""Horizontal line graph"""
+
+from pygal.graph.line import Line
+from pygal.graph.horizontal import HorizontalGraph
+
+
+class HorizontalLine(HorizontalGraph, Line):
+
+    """Horizontal Line graph"""
+
+    def _plot(self):
+        """Draw the lines in reverse order"""
+        for serie in self.series[::-1]:
+            self.line(serie)
+        for serie in self.secondary_series[::-1]:
+            self.line(serie, True)

--- a/pygal/graph/horizontalstackedline.py
+++ b/pygal/graph/horizontalstackedline.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# This file is part of pygal
+#
+# A python svg graph plotting library
+# Copyright © 2012-2015 Kozea
+#
+# This library is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with pygal. If not, see <http://www.gnu.org/licenses/>.
+
+"""Horizontal Stacked Line graph"""
+
+from pygal.graph.stackedline import StackedLine
+from pygal.graph.horizontal import HorizontalGraph
+
+
+class HorizontalStackedLine(HorizontalGraph, StackedLine):
+
+    """Horizontal Stacked Line graph"""
+
+    def _plot(self):
+        """Draw the lines in reverse order"""
+        for serie in self.series[::-1]:
+            self.line(serie)
+        for serie in self.secondary_series[::-1]:
+            self.line(serie, True)

--- a/pygal/graph/line.py
+++ b/pygal/graph/line.py
@@ -148,9 +148,14 @@ class Line(Graph):
     def _compute(self):
         """Compute y min and max and y scale and set labels"""
         # X Labels
-        self._x_pos = [
-            x / (self._len - 1) for x in range(self._len)
-        ] if self._len != 1 else [.5]  # Center if only one value
+        if self.horizontal:
+            self._x_pos = [
+                x / (self._len - 1) for x in range(self._len)
+            ][::-1] if self._len != 1 else [.5]  # Center if only one value
+        else:
+            self._x_pos = [
+                x / (self._len - 1) for x in range(self._len)
+            ] if self._len != 1 else [.5]  # Center if only one value
 
         self._points(self._x_pos)
 

--- a/pygal/test/test_config.py
+++ b/pygal/test/test_config.py
@@ -23,6 +23,7 @@ from pygal import (
     Line, Dot, Pie, Treemap, Radar, Config, Bar, Funnel,
     Histogram, Gauge, Box, XY,
     Pyramid, HorizontalBar, HorizontalStackedBar,
+    HorizontalStackedLine, HorizontalLine,
     DateTimeLine, TimeLine, DateLine, TimeDeltaLine)
 from pygal.graph.map import BaseMap
 from pygal.graph.horizontal import HorizontalGraph
@@ -434,6 +435,7 @@ def test_y_label_major(Chart):
     if Chart in (
             Pie, Treemap, Funnel, Dot, Gauge, Histogram, Box,
             HorizontalBar, HorizontalStackedBar,
+            HorizontalStackedLine, HorizontalLine,
             Pyramid, DateTimeLine, TimeLine, DateLine,
             TimeDeltaLine
     ) or issubclass(Chart, BaseMap):


### PR DESCRIPTION
Hello again,

I added options for Horizontal Line Charts (HorizontalLine and HorizontalStackedLine).

Here's an example:
chart = HorizontalLine(
        range=(0, 50),
        print_values=True
)
chart.add('Series 1', [30, 15, 16, 13, 15], fill=True)
chart.add('Series 2', [11, 25, 26, 23, 25], fill=True)
chart.x_labels = range(1, 6)
return chart.render_response()
![image](https://cloud.githubusercontent.com/assets/13579256/12676346/6eb5fb46-c65f-11e5-9ab1-b11272f9ee9a.png)