### PR TITLE
Added "http:" prefix to js Key in config.py

### DIFF
--- a/pygal/config.py
+++ b/pygal/config.py
@@ -492,7 +492,7 @@ class Config(CommonConfig):
 
     # Misc #
     js = Key(
-        ('//kozea.github.io/pygal.js/2.0.x/pygal-tooltips.min.js',),
+        ('http://kozea.github.io/pygal.js/2.0.x/pygal-tooltips.min.js',),
         list, "Misc", "List of js file",
         "It can be any uri from file:///tmp/ext.js to //domain/ext.js",
         str)


### PR DESCRIPTION
Without the "http:" prefix, embedding files in webpages wasn't succeeding - the local filepath was being searched for the JS file instead of the web.