### PR TITLE
Use datetime.utcfromtimestamp to generate date() object

### DIFF
--- a/pygal/graph/time.py
+++ b/pygal/graph/time.py
@@ -113,7 +113,7 @@ class DateLine(DateTimeLine):
     def _x_format(self):
         """Return the value formatter for this graph"""
         def date_to_str(x):
-            d = date.fromtimestamp(x)
+            d = datetime.utcfromtimestamp(x).date()
             return self.x_value_formatter(d)
         return date_to_str
 


### PR DESCRIPTION
The date.fromtimestamp() method used in DateLine will treat it as local time,
which is inconsistent with the datetime.utcfromtimestamp() method used
in DateTimeLine, and causes tests to fail with timezone issues:

```
>>> from datetime import datetime, date
>>> t = 1473273687.227791
>>> datetime.utcfromtimestamp(t).date()
datetime.date(2016, 9, 7)
>>> date.fromtimestamp(t)
datetime.date(2016, 9, 8)
```

This commit changes the former to a datetime.utcfromtimestamp().date()
call, which will always return consistent result as
datetime.utcfromtimestamp() and thus fixes the tests.
