### PR TITLE
Use [tool:pytest] in setup.cfg as suggested by upstream

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 flake8-ignore =
     *.py E731 E402
     pygal/__init__.py F401


### PR DESCRIPTION
The patch removes this pytest warning:

WC1 None [pytest] section in setup.cfg files is deprecated, use
[tool:pytest] instead.