### PR TITLE
Update World Maps documentation

### DIFF
--- a/docs/documentation/types/maps/pygal_maps_world.rst
+++ b/docs/documentation/types/maps/pygal_maps_world.rst
@@ -251,7 +251,7 @@ tl     Timor-Leste
 tm     Turkmenistan
 tn     Tunisia
 tr     Turkey
-tw     Taiwan, Province of China
+tw     Taiwan (Republic of China)
 tz     Tanzania, United Republic of
 ua     Ukraine
 ug     Uganda


### PR DESCRIPTION
Changed the nomenclature of Taiwan as per [Wikipedia article](https://en.wikipedia.org/wiki/Taiwan).
