### PR TITLE
wrong label colors when there are more series than colors

### DIFF
--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -391,8 +391,7 @@ class Graph(PublicApi):
                     ) / 2,
                     width=self.legend_box_size,
                     height=self.legend_box_size,
-                    class_="color-%d reactive" % (
-                        serie_number % len(self.style.colors))
+                    class_="color-%d reactive" % serie_number
                 )
 
                 if isinstance(title, dict):


### PR DESCRIPTION
if the chart has more series than the colors available in the style(18 in the default one) the colors are darkened in the chart but for the labels the normal colors are reused instead
