### PR TITLE
generalized fix solidgauge squares algorithm issue

### DIFF
--- a/pygal/graph/solidgauge.py
+++ b/pygal/graph/solidgauge.py
@@ -126,7 +126,7 @@ class SolidGauge(Graph):
                     n_series_ = n_series_ / i
                 i = i + 1
             _y = int(n_series_)
-            _x = int(n_series_ / len(self.series))
+            _x = int(len(self.series) / _y)
             if len(self.series) == 5:
                 _x, _y = 2, 3
             if abs(_x - _y) > 2:


### PR DESCRIPTION
Squares algorithm returns (0,1) for following series 8,27,32,54(till 100) causing ZeroDivisionError.

This PR fixes the issue as well as improves grid space usage for other series(e.g. for series 6, original code gives _x,_y=3,3, this fix gives _x,_y=2,3)
