### PR TITLE
Added dot_opacity style option; fixes #387

### DIFF
--- a/pygal/css/graph.css
+++ b/pygal/css/graph.css
@@ -105,7 +105,8 @@
 
 {{ id }}.dot {
   stroke-width: 1px;
-  fill-opacity: 1;
+  fill-opacity: {{ style.dot_opacity }};
+  stroke-opacity: {{ style.dot_opacity }};
 }
 
 {{ id }}.dot.active {

--- a/pygal/style.py
+++ b/pygal/style.py
@@ -69,6 +69,8 @@ class Style(object):
     stroke_opacity = '.8'
     stroke_opacity_hover = '.9'
 
+    dot_opacity = '1'
+
     transition = '150ms'
     colors = (
         '#F44336',  # 0


### PR DESCRIPTION
This would add dot alpha to the list of custom style options - good for overplotting as described in the issue. Fill and stroke opacity are both tied to dot_opacity for uniformity. Would be happy to make changes/add to documentation as needed!