### PR TITLE
Add MANIFEST.in to include demo and docs in PyPi tarballs, fixes #425

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+exclude .* pygal_doc_old.tar.xz tox.ini
+graft demo docs tests
+global-exclude __pycache__ *.py[co]


### PR DESCRIPTION
Hi,
Distributions often rely on PyPI tarballs to build docs. The current PyPI tarballs do not contain them. The sdist file that I obtain with the MANIFEST.in file also contains COPYING, so this fixes #425.

I tried to remove a few files that aren't needed like the old doc tarball, feel free to change the MANIFEST.in file.