### PR TITLE
Fix a Sphinx warning related to a non-existent _static directory

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,7 +150,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
Otherwise, we get:
```
copying static files... WARNING: html_static_path entry '/tmp/pygal/docs/_static' does not exist
```