### PR TITLE
Update Libya name

### DIFF
--- a/docs/documentation/types/maps/pygal_maps_world.rst
+++ b/docs/documentation/types/maps/pygal_maps_world.rst
@@ -183,7 +183,7 @@ ls     Lesotho
 lt     Lithuania
 lu     Luxembourg
 lv     Latvia
-ly     Libyan Arab Jamahiriya
+ly     Libya
 ma     Morocco
 mc     Monaco
 md     Moldova, Republic of


### PR DESCRIPTION
The country was called Libyan Arab Jamahiriya. However, the UN formally recognized the country as "Libya" in September 2011 based on a request from the Permanent Mission of Libya citing the Libyan interim Constitutional Declaration of 3 August 2011.