### PR TITLE
Add secondary_value_formatter to format the second axis values

### DIFF
--- a/pygal/config.py
+++ b/pygal/config.py
@@ -405,6 +405,11 @@ class Config(CommonConfig):
         "A function to convert ordinate numeric value to strings"
     )
 
+    secondary_value_formatter = Key(
+        formatters.default, callable, "Value",
+        "A function to convert ordinate numeric value to strings"
+    )
+
     logarithmic = Key(
         False, bool, "Value", "Display values in logarithmic scale"
     )

--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -346,7 +346,7 @@ class Graph(PublicApi):
                     y=y + .35 * self.style.label_font_size,
                     class_='major' if major else ''
                 )
-                text.text = self._y_2nd_format(label)
+                text.text = label
                 if self.y_label_rotation:
                     text.attrib['transform'] = "rotate(%d %f %f)" % (
                         self.y_label_rotation, x, y

--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -622,7 +622,7 @@ class Graph(PublicApi):
             left_range = abs(y_pos[-1] - y_pos[0])
             right_range = abs(ymax - ymin) or 1
             scale = right_range / ((steps - 1) or 1)
-            self._y_2nd_labels = [(self._y_format(ymin + i * scale), pos)
+            self._y_2nd_labels = [(self._y_2nd_format(ymin + i * scale), pos)
                                   for i, pos in enumerate(y_pos)]
 
             self._scale = left_range / right_range

--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -346,7 +346,7 @@ class Graph(PublicApi):
                     y=y + .35 * self.style.label_font_size,
                     class_='major' if major else ''
                 )
-                text.text = label
+                text.text = self._y_2nd_format(label)
                 if self.y_label_rotation:
                     text.attrib['transform'] = "rotate(%d %f %f)" % (
                         self.y_label_rotation, x, y
@@ -622,7 +622,7 @@ class Graph(PublicApi):
             left_range = abs(y_pos[-1] - y_pos[0])
             right_range = abs(ymax - ymin) or 1
             scale = right_range / ((steps - 1) or 1)
-            self._y_2nd_labels = [(self._y_2nd_format(ymin + i * scale), pos)
+            self._y_2nd_labels = [(self._y_format(ymin + i * scale), pos)
                                   for i, pos in enumerate(y_pos)]
 
             self._scale = left_range / right_range

--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -622,7 +622,7 @@ class Graph(PublicApi):
             left_range = abs(y_pos[-1] - y_pos[0])
             right_range = abs(ymax - ymin) or 1
             scale = right_range / ((steps - 1) or 1)
-            self._y_2nd_labels = [(self._y_format(ymin + i * scale), pos)
+            self._y_2nd_labels = [(self._y_2nd_format(ymin + i * scale), pos)
                                   for i, pos in enumerate(y_pos)]
 
             self._scale = left_range / right_range
@@ -657,6 +657,12 @@ class Graph(PublicApi):
     def _y_format(self):
         """Return the ordinate value formatter (always unary)"""
         return self.value_formatter
+
+    @property
+    def _y_2nd_format(self):
+        """Return the ordinate value formatter for secondary axis
+        (always unary)"""
+        return self.secondary_value_formatter
 
     def _value_format(self, value):
         """


### PR DESCRIPTION
Example usage
```python
pygal.Line(secondary_value_formatter=lambda x: "{:.0f}%".format(x))
```