### PR TITLE
Add `value` attribute to <td> elements for CSS conditional formatting

### DIFF
--- a/docs/documentation/table.rst
+++ b/docs/documentation/table.rst
@@ -79,3 +79,21 @@ Transposed
   line_chart.value_formatter = lambda x: '%.2f%%' % x if x is not None else '∅'
   line_chart.render_table(style=True, total=True, transpose=True)
 
+
+Value Attribute (for CSS Conditional Formatting)
+------------------------------------------------
+
+Add to each <td> element the `value` attribute with the same content of the element itself.
+This can be useful for applying CSS conditional formatting rules.
+
+.. pygal-table-code::
+
+  line_chart = pygal.Bar()
+  line_chart.title = 'Browser usage evolution (in %)'
+  line_chart.x_labels = map(str, range(2002, 2013))
+  line_chart.add('Firefox', [None, None, 0, 16.6,   25,   31, 36.4, 45.5, 46.3, 42.8, 37.1])
+  line_chart.add('Chrome',  [None, None, None, None, None, None,    0,  3.9, 10.8, 23.8, 35.3])
+  line_chart.add('IE',      [85.8, 84.6, 84.7, 74.5,   66, 58.6, 54.7, 44.8, 36.2, 26.6, 20.1])
+  line_chart.add('Others',  [14.2, 15.4, 15.3,  8.9,    9, 10.4,  8.9,  5.8,  6.7,  6.8,  7.5])
+  line_chart.value_formatter = lambda x: '%.2f%%' % x if x is not None else '∅'
+  line_chart.render_table(style=True, total=True, value_attribute=True)

--- a/pygal/table.py
+++ b/pygal/table.py
@@ -45,12 +45,13 @@ class Table(object):
         """Init the table"""
         self.chart = chart
 
-    def render(self, total=False, transpose=False, style=False):
+    def render(self, total=False, transpose=False, style=False, value_attribute=False):
         """Render the HTMTL table of the chart.
 
         `total` can be specified to include data sums
         `transpose` make labels becomes columns
         `style` include scoped style for the table
+        `value_attribute` replicate element value into `value` attribute (<td> elements)
 
         """
         self.chart.setup()
@@ -138,13 +139,19 @@ class Table(object):
         if tbody:
             parts.append(
                 html.tbody(
-                    *[html.tr(*[html.td(_(col)) for col in r]) for r in tbody]
+                    *[html.tr(*(
+                        [html.td(_(col), value=_(col)) for col in r]
+                        if value_attribute else [html.td(_(col)) for col in r]
+                    )) for r in tbody]
                 )
             )
         if tfoot:
             parts.append(
                 html.tfoot(
-                    *[html.tr(*[html.th(_(col)) for col in r]) for r in tfoot]
+                    *[html.tr(*(
+                        [html.th(_(col), value=_(col)) for col in r]
+                        if value_attribute else [html.td(_(col)) for col in r]
+                    )) for r in tfoot]
                 )
             )
 


### PR DESCRIPTION
Hi everyone,

I need to apply pure CSS conditional formatting to rendered tables, something like you can see [here](http://rpbouman.blogspot.com/2015/04/css-tricks-for-conditional-formatting.html).

The result must look like the following table:
![css-conditional-formatting](https://user-images.githubusercontent.com/17831955/54127351-d9bdcd80-4409-11e9-98a9-c80cab98546d.png)

To get this working we need an attribute on the `<td>` elements on which apply the CSS attribute selector rules. 

This PR add to `Table.render()` the `value_attribute` option. If set to True, each `<td>` element value will be replicated into a new `value` attribute added to the `<td>` element itself. If set to False, the table will be rendered as usual.