### PR TITLE
Patch Python 3.8 deprecation warning

### DIFF
--- a/pygal/_compat.py
+++ b/pygal/_compat.py
@@ -20,8 +20,11 @@
 from __future__ import division
 
 import sys
-from collections import Iterable
 from datetime import datetime, timedelta, tzinfo
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 if sys.version_info[0] == 3:
     base = (str, bytes)


### PR DESCRIPTION
This warning has been plaguing me. This fixes it. Forever.
```
py.warnings:110 - .../pygal/_compat.py:23: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```