### PR TITLE
Print values are not center-aligned in pie chart

### DIFF
--- a/pygal/svg.py
+++ b/pygal/svg.py
@@ -296,7 +296,7 @@ class Svg(object):
             and self.graph._x_labels[i][0]
         )
         if angle >= 0.3:  # 0.3 radians is about 17 degrees
-            self.graph._static_value(serie_node, val, x, y, metadata)
+            self.graph._static_value(serie_node, val, x, y, metadata, 'middle')
         return rv
 
     def gauge_background(


### PR DESCRIPTION
I thought it would be better if the print values are center-aligned in pie chart.
Currently it is left-aligned so if I use long value, it doesn't look good.;)
Thanks.