### PR TITLE
Fixed stacked bar node property overriding

### DIFF
--- a/pygal/graph/stackedbar.py
+++ b/pygal/graph/stackedbar.py
@@ -25,6 +25,7 @@ from __future__ import division
 
 from pygal.adapters import none_to_zero
 from pygal.graph.bar import Bar
+from pygal.util import alter
 
 
 class StackedBar(Bar):
@@ -138,16 +139,19 @@ class StackedBar(Bar):
             width -= 2 * serie_margin
         height = self.view.y(zero) - y
         r = serie.rounded_bars * 1 if serie.rounded_bars else 0
-        self.svg.transposable_node(
-            parent,
-            'rect',
-            x=x,
-            y=y,
-            rx=r,
-            ry=r,
-            width=width,
-            height=height,
-            class_='rect reactive tooltip-trigger'
+        alter(
+            self.svg.transposable_node(
+                parent,
+                'rect',
+                x=x,
+                y=y,
+                rx=r,
+                ry=r,
+                width=width,
+                height=height,
+                class_='rect reactive tooltip-trigger'
+            ),
+            serie.metadata.get(i)
         )
         return x, y, width, height
 


### PR DESCRIPTION
Allow to pass node-attribute to StackedGraph like documented for other graphs:
http://www.pygal.org/en/stable/documentation/configuration/value.html#node-attributes.
cheers