### PR TITLE
Fix file uri on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+environment:
+  
+  matrix:
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+ 
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+
+  # Add Python binaries to the path
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "python --version"
+
+  
+install:
+  # Upgrade PIP and setuptools to allow installation of pre-compiled wheels instead of compiling by ourselves
+  - "python -m pip install --upgrade pip"
+  - "pip install --upgrade setuptools"
+  
+  - "pip install -e .[test]"
+  
+build: off
+
+test_script:
+  # Run test files via py.test and generate JUnit XML. Then push test results
+  # to appveyor. The plugin pytest-cov takes care of coverage.
+  - ps: |
+      & pytest -W ignore::DeprecationWarning --junitxml=.\unittests.xml pygal/test
+      $testsExitCode = $lastexitcode
+
+      # Upload test results to AppVeyor
+      $wc = New-Object 'System.Net.WebClient'
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\unittests.xml))
+
+      if ($testsExitCode -ne 0) {exit $testsExitCode}  
+
+artifacts:
+  - path: .\unittests.xml
+
+cache:
+  - '%LOCALAPPDATA%\\pip\\Cache'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,3 @@ test_script:
 
 artifacts:
   - path: .\unittests.xml
-
-cache:
-  - '%LOCALAPPDATA%\\pip\\Cache'

--- a/pygal/test/test_graph.py
+++ b/pygal/test/test_graph.py
@@ -47,7 +47,7 @@ def test_multi_render(Chart, datas):
 
 def test_render_to_file(Chart, datas, tmpdir):
     """Test in file rendering"""
-    file_name = tmpdir.join('test_graph-%s.png' % uuid.uuid4())
+    file_name = str(tmpdir.join('test_graph-%s.png' % uuid.uuid4()))
     if os.path.exists(file_name):
         os.remove(file_name)
 
@@ -62,7 +62,7 @@ def test_render_to_file(Chart, datas, tmpdir):
 @pytest.mark.skipif(not cairosvg, reason="CairoSVG not installed")
 def test_render_to_png(Chart, datas, tmpdir):
     """Test in file png rendering"""
-    file_name = tmpdir.join('test_graph-%s.png' % uuid.uuid4())
+    file_name = str(tmpdir.join('test_graph-%s.png' % uuid.uuid4()))
     if os.path.exists(file_name):
         os.remove(file_name)
 

--- a/pygal/test/test_graph.py
+++ b/pygal/test/test_graph.py
@@ -32,7 +32,7 @@ from pygal.util import cut
 
 try:
     import cairosvg
-except ImportError:
+except (ImportError, OSError):  # OSError is raised on Windows if cairo's DLLs are missing
     cairosvg = None
 
 
@@ -45,9 +45,9 @@ def test_multi_render(Chart, datas):
         assert svg == chart.render()
 
 
-def test_render_to_file(Chart, datas):
+def test_render_to_file(Chart, datas, tmpdir):
     """Test in file rendering"""
-    file_name = '/tmp/test_graph-%s.svg' % uuid.uuid4()
+    file_name = tmpdir.join('test_graph-%s.png' % uuid.uuid4())
     if os.path.exists(file_name):
         os.remove(file_name)
 
@@ -60,9 +60,9 @@ def test_render_to_file(Chart, datas):
 
 
 @pytest.mark.skipif(not cairosvg, reason="CairoSVG not installed")
-def test_render_to_png(Chart, datas):
+def test_render_to_png(Chart, datas, tmpdir):
     """Test in file png rendering"""
-    file_name = '/tmp/test_graph-%s.png' % uuid.uuid4()
+    file_name = tmpdir.join('test_graph-%s.png' % uuid.uuid4())
     if os.path.exists(file_name):
         os.remove(file_name)
 


### PR DESCRIPTION
Fix issue with parsing of file URIs on Windows and URL-encoded characters (%xx) on both Windows and *nix.

On Windows, file URI "file:///c:/dir/file.css" should be converted to "c:/dir/file.css" rather than to "/c:/dir/file.css".

URL-encoded characters should be converted to regular UTF-8 characters, for example, "%20" to " " (space).
So, "file:///c:/Program%20Files/file.css" becomes "c:/Program Files/file.css"