### PR TITLE
Add style property for tooltip background.

### DIFF
--- a/pygal/css/style.css
+++ b/pygal/css/style.css
@@ -117,7 +117,7 @@
 }
 
 {{ id }}.tooltip rect {
-  fill: {{ style.plot_background }};
+  fill: {{ style.tooltip_background }};
   stroke: {{ style.foreground_strong }};
   -webkit-transition: opacity {{ style.transition }};
   -moz-transition: opacity {{ style.transition }};

--- a/pygal/style.py
+++ b/pygal/style.py
@@ -30,6 +30,7 @@ class Style(object):
     """Styling class containing colors for the css generation"""
 
     plot_background = 'rgba(255, 255, 255, 1)'
+    tooltip_background = None
     background = 'rgba(249, 249, 249, 1)'
     value_background = 'rgba(229, 229, 229, 1)'
     foreground = 'rgba(0, 0, 0, .87)'
@@ -105,6 +106,9 @@ class Style(object):
         if self.font_family.startswith('googlefont:'):
             self.font_family = self.font_family.replace('googlefont:', '')
             self._google_fonts.add(self.font_family.split(',')[0].strip())
+
+        if self.tooltip_background is None:
+            self.tooltip_background = self.plot_background
 
         for name in dir(self):
             if name.endswith('_font_family'):


### PR DESCRIPTION
Hi,

I have added a property to set a seperate tooltip background. If left unspecified the tooltip background reverts to the plot background so this does not break any of the included styles. This fixes my own issue (or feature request) #502.

I have run the built in tests and also run this short example to make sure the property actually works as intended:

[https://gist.github.com/danieldean/cde51a2aba560226c92daed91b8babfa](https://gist.github.com/danieldean/cde51a2aba560226c92daed91b8babfa)

Hopefully I have done this right!

Thanks