### PR TITLE
docs: fix simple typo, lenght -> length

### DIFF
--- a/docs/documentation/configuration/label.rst
+++ b/docs/documentation/configuration/label.rst
@@ -239,7 +239,7 @@ truncate_label
 
 By default long labels are automatically truncated at reasonable length to fit in the graph.
 
-You can override that by setting truncation lenght with ``truncate_label``.
+You can override that by setting truncation length with ``truncate_label``.
 
 
 .. pygal-code::

--- a/docs/documentation/configuration/legend.rst
+++ b/docs/documentation/configuration/legend.rst
@@ -60,7 +60,7 @@ truncate_legend
 
 By default long legends are automatically truncated at reasonable length to fit in the graph.
 
-You can override that by setting truncation lenght with ``truncate_legend``.
+You can override that by setting truncation length with ``truncate_legend``.
 
 
 .. pygal-code::


### PR DESCRIPTION
There is a small typo in docs/documentation/configuration/label.rst, docs/documentation/configuration/legend.rst.

Should read `length` rather than `lenght`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md