### PR TITLE
Fixed unnecessary legend item after setting title in histogram

### DIFF
--- a/pygal/graph/base.py
+++ b/pygal/graph/base.py
@@ -162,10 +162,11 @@ class BaseGraph(object):
 
                 values.append(value)
             serie_config = SerieConfig()
-            serie_config(
-                **dict((k, v) for k, v in self.state.__dict__.items()
-                       if k in dir(serie_config))
-            )
+            if not isinstance(self, Histogram):
+                serie_config(
+                    **dict((k, v) for k, v in self.state.__dict__.items()
+                        if k in dir(serie_config))
+                )
             serie_config(**serie_config_kwargs)
             series.append(
                 Serie(offset + len(series), values, serie_config, metadata)


### PR DESCRIPTION
When I manage to set the title in histogram by using `self.chart.title = 'xxx'`, I find that there will be an unexpected legend item named `xxx` appeared.
Perhaps the `BaseGraph` class process one more `SerieConfig()`. And after the title being set, the content in the additional `SerieConfig` object will not be `None`, thus the problem happens.