### PR TITLE
Prevent installing on unsupported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     author_email=about['__email__'],
     license=about['__license__'],
     platforms="Any",
+    python_requires=">=3.6",
     packages=find_packages(),
     provides=['pygal'],
     scripts=["pygal_gen.py"],


### PR DESCRIPTION
PyGal 3.0.0 was recently released, which drops support for a number of legacy Python versions. Unfortunately, it does not take advantage of the `python_requires` option, which marks this version of PyGal as unsuitable for installing on these legacy Python versions, meaning `pip install pygal` on these older versions will attempt to install the latest (unsupported) version of PyGal.

Note that merely merging this change and releasing the new version is not sufficient. Once the new version has been released (presumably 3.0.1) It is also necessary to yank the previously released version (3.0.0), so that it does not appear as an installation candidate for older versions of Python.