### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ setup(
     version=about['__version__'],
     description=about['__summary__'],
     url=about['__uri__'],
+    project_urls={
+        'Source': 'https://github.com/Kozea/pygal',
+    },
     author=about['__author__'],
     author_email=about['__email__'],
     license=about['__license__'],


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)