### PR TITLE
Use entry_points directly instead of as dict

### DIFF
--- a/pygal/__init__.py
+++ b/pygal/__init__.py
@@ -61,7 +61,7 @@ CHARTS_BY_NAME = dict([
 
 from pygal.graph.map import BaseMap
 
-for entry in entry_points().get('pygal.maps', ()):
+for entry in entry_points(group="pygal.maps"):
     try:
         module = entry.load()
     except Exception:

--- a/pygal/test/test_maps.py
+++ b/pygal/test/test_maps.py
@@ -21,7 +21,7 @@
 from importlib.metadata import entry_points
 
 # Load plugins tests
-for entry in entry_points().get('pygal.test.test_maps', ()):
+for entry in entry_points(group="pygal.test.test_maps"):
     module = entry.load()
     for k, v in module.__dict__.items():
         if k.startswith('test_'):


### PR DESCRIPTION
This is necessary to submit to a deprecation warning in `importlib.metadata`. See [this issue](https://github.com/python/importlib_metadata/issues/409) and [the docs](https://docs.python.org/3/library/importlib.metadata.html#entry-points).

The test suite seemed to pass.