### PR TITLE
Use importlib.metadata (pygal requires 3.8+)

### DIFF
--- a/pygal/__init__.py
+++ b/pygal/__init__.py
@@ -29,7 +29,7 @@ import sys
 import traceback
 import warnings
 
-from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 from pygal import maps
 from pygal.config import Config
@@ -62,7 +62,10 @@ CHARTS_BY_NAME = dict([
 
 from pygal.graph.map import BaseMap
 
-for entry in entry_points(group="pygal.maps"):
+for entry in entry_points():
+    # TODO: when targeting Python 3.10+, this can use `entry_points(group=...)`.
+    if entry.group != "pygal.maps":
+        continue
     try:
         module = entry.load()
     except Exception:

--- a/pygal/test/test_maps.py
+++ b/pygal/test/test_maps.py
@@ -18,10 +18,13 @@
 # along with pygal. If not, see <http://www.gnu.org/licenses/>.
 """Map plugins tests are imported here"""
 
-from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 # Load plugins tests
-for entry in entry_points(group="pygal.test.test_maps"):
+for entry in entry_points():
+    # TODO: when targeting Python 3.10+, this can use `entry_points(group=...)`.
+    if entry.group != "pygal.test.test_maps":
+        continue
     module = entry.load()
     for k, v in module.__dict__.items():
         if k.startswith('test_'):


### PR DESCRIPTION
Fixes https://github.com/Kozea/pygal/issues/545#issuecomment-1820314396

`importlib_metadata` from PyPI is only required for Python < 3.8; `importlib.metadata` is always available on 3.8+, and the minimum `python_requires` here is 3.8+ (https://github.com/Kozea/pygal/commit/01649cb5d3295ba2a7e1a47e79f924068f1ebb71).

Regressed in https://github.com/Kozea/pygal/commit/d1d02c69891ddd5367903ea0bb11d260c3cac219