### PR TITLE
Add importlib_metadata as a real dependency for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
     setup_requires=['pytest-runner'],
     cmdclass={'test': PyTest},
     package_data={'pygal': ['css/*', 'graph/maps/*.svg']},
+    install_requires=["importlib_metadata"],  # TODO: remove this (see #545, #546)
     extras_require={
         'lxml': ['lxml'],
         'docs': ['sphinx', 'sphinx_rtd_theme', 'pygal_sphinx_directives'],

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ deps =
      lxml
      pyquery
      cairosvg
-     importlib_metadata
 
 setenv =
     COVERAGE_FILE=.cov-{envname}


### PR DESCRIPTION
This is an alternate take to #546 that will make this package installable in general without having to specify `importlib_metadata` as a downstream dependency.

Using `importlib.metadata` directly (as implemented in #546) is the better solution, but this should allow for releasing a 3.0.4 as a stopgap measure.