### PR TITLE
Coveralls: Pass $GITHUB_TOKEN to get coveralls.io working again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,10 @@ jobs:
           cache: pip
       - run: pip install coveralls tox tox-gh
       - run: tox
-      - env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
+          COVERALLS_PARALLEL: true
         run: coveralls
         continue-on-error: true
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
           cache: pip
       - run: pip install coveralls tox tox-gh
       - run: tox
-      - run: coveralls
+      - env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: coveralls
         continue-on-error: true
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ on:
     branches:
       - master
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
+      - run: pip install ruff
+      - run: ruff --output-format=github
   test:
     runs-on: '${{ matrix.os }}'
     strategy:
@@ -38,13 +48,15 @@ jobs:
           COVERALLS_PARALLEL: true
         run: coveralls
         continue-on-error: true
-  lint:
+  coveralls:
+    name: Indicate completion to coveralls.io
+    needs: test
     runs-on: ubuntu-latest
+    container: python:3-slim
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-          cache: pip
-      - run: make install  # TODO: this should only install lint dependencies
-      - run: make lint
+    - name: Finished
+      run: |
+        pip3 install --upgrade coveralls
+        coveralls --service=github --finish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-          cache: pip
-      - run: pip install ruff
+      - run: pip install --user ruff
       - run: ruff --output-format=github
   test:
     runs-on: '${{ matrix.os }}'

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 setenv =
     COVERAGE_FILE=.cov-{envname}
 commands =
-    coverage run pytest --junitxml=junit-{envname}.xml
+    coverage run {envbindir}/pytest --junitxml=junit-{envname}.xml
     coverage run --source=pygal {envbindir}/py.test {posargs:pygal/test} --junitxml=junit-{envname}.xml
     coverage xml -o coverage-{envname}.xml
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ setenv =
     COVERAGE_FILE=.cov-{envname}
 commands =
     coverage run {envbindir}/pytest --junitxml=junit-{envname}.xml
-    coverage run --source=pygal {envbindir}/py.test {posargs:pygal/test} --junitxml=junit-{envname}.xml
     coverage xml -o coverage-{envname}.xml
 
 [gh]

--- a/tox.ini
+++ b/tox.ini
@@ -3,15 +3,16 @@ envlist = py38,py39,py310,py311,py312,pypy
 
 [testenv]
 deps =
-     pytest
+     cairosvg
      coverage
      lxml
      pyquery
-     cairosvg
+     pytest
 
 setenv =
     COVERAGE_FILE=.cov-{envname}
 commands =
+    coverage run pytest --junitxml=junit-{envname}.xml
     coverage run --source=pygal {envbindir}/py.test {posargs:pygal/test} --junitxml=junit-{envname}.xml
     coverage xml -o coverage-{envname}.xml
 


### PR DESCRIPTION
Fix these errors...
* https://github.com/Kozea/pygal/actions/runs/7168325592/job/19516257331 under `Run coveralls`...
```
Run coveralls
Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/coveralls/cli.py", line 64, in main
    coverallz = Coveralls(token_required,
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/coveralls/api.py", line 49, in __init__
    self.ensure_token()
  File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/coveralls/api.py", line 56, in ensure_token
    raise CoverallsException(
coveralls.exception.CoverallsException: Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
```
* https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support
# --> https://coveralls.io/github/Kozea/pygal
Scroll down to see that these are the first coveralls updates for this project since 2017.