### PR TITLE
Remove test from setup.py, unify test requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	rm -fr *.egg-info
 
 lint:
-	$(RUFF) $(PROJECT_NAME)
+	$(RUFF) check $(PROJECT_NAME)
 
 check:
 	$(PYTEST) $(PROJECT_NAME) $(PYTEST_ARGS) --cov-report= --cov=pygal

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,4 @@
+[lint]
 extend-select = [
     "E",
     "F",
@@ -10,13 +11,14 @@ extend-select = [
 ]
 
 ignore = [
+    "E721",  # TODO: do not ignore?
     "E731",
     "E741",
     "PLW2901",  # TODO: do not ignore?
     "PLW3301",  # TODO: do not ignore?
 ]
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "pygal/__init__.py" = [
     "E402",
     "F401",

--- a/setup.py
+++ b/setup.py
@@ -18,34 +18,26 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with pygal. If not, see <http://www.gnu.org/licenses/>.
 import os
-import sys
 
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
-
-
-class PyTest(TestCommand):
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = ['-x', 'build/lib/pygal']
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.test_args)
-        sys.exit(errno)
-
 
 ROOT = os.path.dirname(__file__)
 
-
 tests_requirements = [
-    "pyquery", "flask", 'cairosvg', 'lxml', 'pygal_maps_world', 'pygal_maps_fr',
-    'pygal_maps_ch', 'coveralls',
-    'ruff',
-    'pytest-runner', 'pytest-cov',
-    'pytest'
+    "cairosvg",
+    "coveralls",
+    "lxml",
+    "pyquery",
+    "pytest",
+    "pytest-cov",
+    "ruff",
+]
+
+moulinrouge_requirements = [
+    "flask",
+    "pygal_maps_ch",
+    "pygal_maps_fr",
+    "pygal_maps_world",
 ]
 
 about = {}
@@ -72,13 +64,13 @@ setup(
         "svg", "chart", "graph", "diagram", "plot", "histogram", "kiviat"],
     setup_requires=['pytest-runner'],
     install_requires=['importlib-metadata'],  # TODO: remove this (see #545, #546)
-    cmdclass={'test': PyTest},
     package_data={'pygal': ['css/*', 'graph/maps/*.svg']},
     extras_require={
         'lxml': ['lxml'],
         'docs': ['sphinx', 'sphinx_rtd_theme', 'pygal_sphinx_directives'],
         'png': ['cairosvg'],
-        'test': tests_requirements
+        'test': tests_requirements,
+        'moulinrouge': moulinrouge_requirements,
     },
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ tests_requirements = [
     "pyquery",
     "pytest",
     "pytest-cov",
-    "ruff",
+    "ruff>=0.5.5",
 ]
 
 moulinrouge_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ tests_requirements = [
     "pyquery",
     "pytest",
     "pytest-cov",
-    "ruff>=0.5.5",
+    "ruff>=0.5.6",
 ]
 
 moulinrouge_requirements = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,7 @@
 envlist = py38,py39,py310,py311,py312,pypy
 
 [testenv]
-deps =
-     pytest
-     coverage
-     lxml
-     pyquery
-     cairosvg
-
+extras = test
 setenv =
     COVERAGE_FILE=.cov-{envname}
 commands =


### PR DESCRIPTION
See https://github.com/pypa/setuptools/issues/931 – `setuptools>=72` removes the test module.

I also noticed `tox` specified different test requirements than `setup.py`.
