### PR TITLE
Created a Reversible Gauge Graph Option

### DIFF
--- a/pygal/graph/gauge.py
+++ b/pygal/graph/gauge.py
@@ -22,11 +22,15 @@ from pygal.graph.graph import Graph
 from pygal.util import alter, compute_scale, cut, decorate
 from pygal.view import PolarThetaLogView, PolarThetaView
 
-
 class Gauge(Graph):
     """Gauge graph class"""
 
     needle_width = 1 / 20
+
+    def __init__(self, *args, reverse_direction=False, **kwargs):
+        """Initialize the gauge with direction configuration"""
+        super(Gauge, self).__init__(*args, **kwargs)
+        self.reverse_direction = reverse_direction
 
     def _set_view(self):
         """Assign a view to current graph"""
@@ -132,7 +136,10 @@ class Gauge(Graph):
             self.min_ -= 1
             self.max_ += 1
 
-        self._box.set_polar_box(0, 1, self.min_, self.max_)
+        if self.reverse_direction:
+            self._box.set_polar_box(0, 1, self.max_, self.min_)
+        else:
+            self._box.set_polar_box(0, 1, self.min_, self.max_)
 
     def _compute_x_labels(self):
         pass


### PR DESCRIPTION
By default, the gauge graph only had the option to display its y-value from largest starting on the right side and smallest of the left. With the changes made, users can reverse this option by initializing the Gauge with the `reverse_direction` configuration. 

### `reverse_direction = true` 
<img width="1270" alt="Screenshot 2024-11-04 at 10 46 23 AM" src="https://github.com/user-attachments/assets/188f3f70-2638-42e3-9209-a1ba7c2b4651">

### `reverse_direction = false` 
<img width="1270" alt="Screenshot 2024-11-04 at 10 46 37 AM" src="https://github.com/user-attachments/assets/cae10269-4049-4ee0-b4e8-a69d8761b11f">
