### PR TITLE
Make serie activate serie ids are unique

### DIFF
--- a/pygal/graph/graph.py
+++ b/pygal/graph/graph.py
@@ -441,7 +441,7 @@ class Graph(PublicApi):
                 legend = self.svg.node(
                     secondary_legends if is_secondary else legends,
                     class_='legend reactive activate-serie',
-                    id="activate-serie-%d" % serie_number
+                    id=f"activate-serie-{self.uuid}-{serie_number}"
                 )
                 self.svg.node(
                     legend,

--- a/pygal/svg.py
+++ b/pygal/svg.py
@@ -229,15 +229,18 @@ class Svg(object):
         return dict(
             plot=self.node(
                 self.graph.nodes['plot'],
-                class_='series serie-%d color-%d' % (serie.index, serie.index)
+                class_=f'series serie-{self.graph.uuid}-{serie.index} '
+                       f'color-{serie.index}'
             ),
             overlay=self.node(
                 self.graph.nodes['overlay'],
-                class_='series serie-%d color-%d' % (serie.index, serie.index)
+                class_=f'series serie-{self.graph.uuid}-{serie.index} '
+                       f'color-{serie.index}'
             ),
             text_overlay=self.node(
                 self.graph.nodes['text_overlay'],
-                class_='series serie-%d color-%d' % (serie.index, serie.index)
+                class_=f'series serie-{self.graph.uuid}-{serie.index} '
+                       f'color-{serie.index}'
             )
         )
 

--- a/pygal/test/test_config.py
+++ b/pygal/test/test_config.py
@@ -79,6 +79,7 @@ def test_config_behaviours():
         no_prefix=True,
         x_labels=['a', 'b', 'c']
     )
+    line2.uuid = line1.uuid
     line2.add('_', [1, 2, 3])
     l2 = line2.render()
     assert l1 == l2
@@ -91,11 +92,13 @@ def test_config_behaviours():
         x_labels = ['a', 'b', 'c']
 
     line3 = Line(LineConfig)
+    line3.uuid = line1.uuid
     line3.add('_', [1, 2, 3])
     l3 = line3.render()
     assert l1 == l3
 
     line4 = Line(LineConfig())
+    line4.uuid = line1.uuid
     line4.add('_', [1, 2, 3])
     l4 = line4.render()
     assert l1 == l4
@@ -108,11 +111,13 @@ def test_config_behaviours():
     line_config.x_labels = ['a', 'b', 'c']
 
     line5 = Line(line_config)
+    line5.uuid = line1.uuid
     line5.add('_', [1, 2, 3])
     l5 = line5.render()
     assert l1 == l5
-
-    l6 = Line(line_config)(1, 2, 3, title='_').render()
+    line6 = Line(line_config)(1, 2, 3, title='_')
+    line6.uuid = line1.uuid
+    l6 = line6.render()
     assert l1 == l6
 
 
@@ -186,12 +191,14 @@ def test_config_alterations_kwargs():
     assert l1 != l1bis
 
     line2 = Line(config)
+    line2.uuid = line1.uuid
     line2.add('_', [1, 2, 3])
     l2 = line2.render()
     assert l1 == l2
     assert l1bis != l2
 
     line3 = Line(config, title='Title')
+    line3.uuid = line1.uuid
     line3.add('_', [1, 2, 3])
     l3 = line3.render()
     assert l3 != l2

--- a/pygal/test/test_graph.py
+++ b/pygal/test/test_graph.py
@@ -187,7 +187,10 @@ def test_non_iterable_value(Chart):
     if not chart._dual:
         chart.x_labels = ('red', 'green', 'blue')
     chart1 = chart.render()
+    chart_id = chart.uuid
+
     chart = Chart(no_prefix=True)
+    chart.uuid = chart_id  # Ensure UUID is not a source of difference
     chart.add('A', [1])
     chart.add('B', [2])
     if not chart._dual:
@@ -204,8 +207,10 @@ def test_iterable_types(Chart):
     if not chart._dual:
         chart.x_labels = ('red', 'green', 'blue')
     chart1 = chart.render()
+    chart_id = chart.uuid
 
     chart = Chart(no_prefix=True)
+    chart.uuid = chart_id  # Ensure UUID is not a source of difference
     chart.add('A', (1, 2))
     chart.add('B', tuple())
     if not chart._dual:
@@ -218,6 +223,7 @@ def test_values_by_dict(Chart):
     """Test serie as dict"""
     chart1 = Chart(no_prefix=True)
     chart2 = Chart(no_prefix=True)
+    chart2.uuid = chart1.uuid  # Ensure UUID is not a source of difference
 
     if not issubclass(Chart, BaseMap) and not Chart._dual:
         chart1.add('A', {'red': 10, 'green': 12, 'blue': 14})

--- a/pygal/test/test_serie_config.py
+++ b/pygal/test/test_serie_config.py
@@ -30,10 +30,10 @@ def test_no_serie_config():
     chart.add('1', s1)
     chart.add('2', s2)
     q = chart.render_pyquery()
-    assert len(q('.serie-0 .line')) == 1
-    assert len(q('.serie-1 .line')) == 1
-    assert len(q('.serie-0 .dot')) == 5
-    assert len(q('.serie-1 .dot')) == 6
+    assert len(q(f'.serie-{chart.uuid}-0 .line')) == 1
+    assert len(q(f'.serie-{chart.uuid}-1 .line')) == 1
+    assert len(q(f'.serie-{chart.uuid}-0 .dot')) == 5
+    assert len(q(f'.serie-{chart.uuid}-1 .dot')) == 6
 
 
 def test_global_config():
@@ -42,10 +42,10 @@ def test_global_config():
     chart.add('1', s1)
     chart.add('2', s2)
     q = chart.render_pyquery()
-    assert len(q('.serie-0 .line')) == 0
-    assert len(q('.serie-1 .line')) == 0
-    assert len(q('.serie-0 .dot')) == 5
-    assert len(q('.serie-1 .dot')) == 6
+    assert len(q(f'.serie-{chart.uuid}-0 .line')) == 0
+    assert len(q(f'.serie-{chart.uuid}-1 .line')) == 0
+    assert len(q(f'.serie-{chart.uuid}-0 .dot')) == 5
+    assert len(q(f'.serie-{chart.uuid}-1 .dot')) == 6
 
 
 def test_serie_config():
@@ -54,10 +54,10 @@ def test_serie_config():
     chart.add('1', s1, stroke=False)
     chart.add('2', s2)
     q = chart.render_pyquery()
-    assert len(q('.serie-0 .line')) == 0
-    assert len(q('.serie-1 .line')) == 1
-    assert len(q('.serie-0 .dot')) == 5
-    assert len(q('.serie-1 .dot')) == 6
+    assert len(q(f'.serie-{chart.uuid}-0 .line')) == 0
+    assert len(q(f'.serie-{chart.uuid}-1 .line')) == 1
+    assert len(q(f'.serie-{chart.uuid}-0 .dot')) == 5
+    assert len(q(f'.serie-{chart.uuid}-1 .dot')) == 6
 
 
 def test_serie_precedence_over_global_config():
@@ -66,7 +66,7 @@ def test_serie_precedence_over_global_config():
     chart.add('1', s1, stroke=True)
     chart.add('2', s2)
     q = chart.render_pyquery()
-    assert len(q('.serie-0 .line')) == 1
-    assert len(q('.serie-1 .line')) == 0
-    assert len(q('.serie-0 .dot')) == 5
-    assert len(q('.serie-1 .dot')) == 6
+    assert len(q(f'.serie-{chart.uuid}-0 .line')) == 1
+    assert len(q(f'.serie-{chart.uuid}-1 .line')) == 0
+    assert len(q(f'.serie-{chart.uuid}-0 .dot')) == 5
+    assert len(q(f'.serie-{chart.uuid}-1 .dot')) == 6


### PR DESCRIPTION
Fixes #563 

This allows embedding multiple graphs in the same html page without series having conflicting IDs. This is done by including the graph uuid in the serie id.