### PR TITLE
Remove pytest-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
     scripts=["pygal_gen.py"],
     keywords=[
         "svg", "chart", "graph", "diagram", "plot", "histogram", "kiviat"],
-    setup_requires=['pytest-runner'],
     install_requires=['importlib-metadata'],  # TODO: remove this (see #545, #546)
     package_data={'pygal': ['css/*', 'graph/maps/*.svg']},
     extras_require={


### PR DESCRIPTION
The `pytest-runner` package has been deprecated upstream for some time, and the project is now archived:
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice

Furthermore, the "setup.py test" command was removed in setuptools 72: https://github.com/pypa/setuptools/blob/v75.8.0/NEWS.rst#v7200

This does not affect running the tests with `pytest` or `tox`.


Fixes #430.