### PR TITLE
feat: add candlestick chart

### DIFF
--- a/docs/documentation/types/candlestick.rst
+++ b/docs/documentation/types/candlestick.rst
@@ -1,0 +1,23 @@
+Candlestick
+===========
+
+Candlestick charts display open-high-low-close (OHLC) data, commonly used for
+financial market prices.
+
+Each value is a tuple in the form ``(open, high, low, close)``:
+
+.. pygal-code::
+
+  candlestick_chart = pygal.Candlestick()
+  candlestick_chart.title = 'OHLC sample'
+  candlestick_chart.x_labels = ['Mon', 'Tue', 'Wed', 'Thu']
+  candlestick_chart.add('AAPL', [
+      (10, 15, 8, 12),
+      (12, 18, 10, 11),
+      (11, 14, 9, 14),
+      (14, 16, 12, 13),
+  ])
+  candlestick_chart.render()
+
+Missing values can be represented with ``None`` and are rendered as gaps.
+Single numeric values are also accepted and are rendered as doji candles.

--- a/docs/documentation/types/index.rst
+++ b/docs/documentation/types/index.rst
@@ -13,6 +13,7 @@ pygal provides various kinds of charts:
    pie
    radar
    box
+   candlestick
    dot
    funnel
    solidgauge

--- a/pygal/__init__.py
+++ b/pygal/__init__.py
@@ -35,6 +35,7 @@ from pygal import maps
 from pygal.config import Config
 from pygal.graph.bar import Bar
 from pygal.graph.box import Box
+from pygal.graph.candlestick import Candlestick
 from pygal.graph.dot import Dot
 from pygal.graph.funnel import Funnel
 from pygal.graph.gauge import Gauge

--- a/pygal/graph/candlestick.py
+++ b/pygal/graph/candlestick.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+# This file is part of pygal
+#
+# A python svg graph plotting library
+# Copyright © 2012-2025 Kozea
+#
+# This library is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with pygal. If not, see <http://www.gnu.org/licenses/>.
+"""Candlestick chart: display open-high-low-close market data."""
+
+from pygal.graph.graph import Graph
+from pygal.util import alter, cached_property, decorate
+
+
+class Candlestick(Graph):
+    """
+    Candlestick chart.
+
+    Values must be ``(open, high, low, close)`` tuples. Single numeric values
+    render as doji candles for compatibility with generic graph helpers.
+    ``None`` values are allowed and render as gaps.
+    """
+
+    _series_margin = .06
+    _serie_margin = .08
+
+    @staticmethod
+    def _is_ohlc(value):
+        """Return whether a value looks like an OHLC tuple."""
+        return isinstance(value, (list, tuple)) and len(value) == 4
+
+    def _prices(self, value):
+        """Yield adapted price values for axis scaling."""
+        if value is None:
+            return
+        if self._is_ohlc(value):
+            values = value
+        elif isinstance(value, (list, tuple)):
+            return
+        else:
+            values = (value, )
+
+        for price in values:
+            if price is not None:
+                price = self._adapt(price)
+                if price is not None:
+                    yield price
+
+    def _normalize_ohlc(self, value):
+        """Validate and adapt a raw OHLC value."""
+        if value is None:
+            return None
+        if not self._is_ohlc(value):
+            if isinstance(value, (list, tuple)):
+                raise ValueError(
+                    'Candlestick values must be '
+                    '(open, high, low, close) tuples'
+                )
+            value = self._adapt(value)
+            if value is None:
+                return None
+            return (value, value, value, value)
+
+        open_, high, low, close = value
+        if None in value:
+            return None
+        open_, high, low, close = tuple(
+            map(self._adapt, (open_, high, low, close))
+        )
+        if None in (open_, high, low, close):
+            return None
+        if high < max(open_, close) or low > min(open_, close):
+            raise ValueError(
+                'Candlestick high/low values must contain open and close'
+            )
+        return open_, high, low, close
+
+    @cached_property
+    def _values(self):
+        """Flatten OHLC tuples into numeric values for y-axis scaling."""
+        return [
+            price
+            for serie in self.series
+            for value in serie.values
+            for price in self._prices(value)
+        ]
+
+    @cached_property
+    def _secondary_values(self):
+        """Flatten secondary OHLC tuples into numeric values."""
+        return [
+            price
+            for serie in self.secondary_series
+            for value in serie.values
+            for price in self._prices(value)
+        ]
+
+    def _value_format(self, value):
+        """Format OHLC values for tooltip display."""
+        if value is None:
+            return ''
+        if not self._is_ohlc(value):
+            return self._y_format(value)
+        open_, high, low, close = value
+        return 'Open: %s\nHigh: %s\nLow: %s\nClose: %s' % (
+            self._y_format(open_),
+            self._y_format(high),
+            self._y_format(low),
+            self._y_format(close),
+        )
+
+    def _compute(self):
+        """Compute axes and normalize series values."""
+        self.interpolate = None
+
+        if self._values:
+            if self.include_x_axis:
+                self._box.ymin = min(self._min, self.zero)
+                self._box.ymax = max(self._max, self.zero)
+            else:
+                self._box.ymin = self._min
+                self._box.ymax = self._max
+
+        self._x_pos = [
+            x / self._len for x in range(self._len + 1)
+        ] if self._len > 1 else [0, 1]
+        self._points(self._x_pos)
+        self._x_pos = [(i + .5) / self._len for i in range(self._len)] \
+            if self._len else []
+
+        for serie in self.all_series:
+            serie.points = [
+                (self._x_pos[i], self._normalize_ohlc(value))
+                for i, value in enumerate(serie.values)
+            ]
+
+    def _plot(self):
+        """Draw candlesticks for each series."""
+        for serie in self.series:
+            self.candlesticks(serie)
+        for serie in self.secondary_series:
+            self.candlesticks(serie)
+
+    def candlesticks(self, serie):
+        """Draw an OHLC candlestick series."""
+        serie_node = self.svg.serie(serie)
+        candles = self.svg.node(serie_node['plot'], class_='candlesticks')
+
+        for index, (x_pos, value) in enumerate(serie.points):
+            if value is None:
+                continue
+
+            metadata = serie.metadata.get(index)
+            open_, high, low, close = value
+            direction = 'up' if close >= open_ else 'down'
+            candle = decorate(
+                self.svg,
+                self.svg.node(candles, class_='candle %s' % direction),
+                metadata
+            )
+
+            x, y = self._draw_candle(
+                candle, x_pos, open_, high, low, close, serie.index, metadata
+            )
+            self._tooltip_data(
+                candle, self._format(serie, index), x, y,
+                xlabel=self._get_x_label(index)
+            )
+            self._static_value(
+                serie_node, self._format(serie, index), x, y,
+                metadata, 'middle'
+            )
+
+    def _draw_candle(
+            self, node, x_pos, open_, high, low, close, serie_index, metadata
+    ):
+        """Draw a single candle and return its visual center."""
+        slot_width = self.view.width / (self._len or 1)
+        slot_left = self.view.x(x_pos) - slot_width / 2
+        series_margin = slot_width * self._series_margin
+        series_width = slot_width - 2 * series_margin
+        candle_slot_width = series_width / (self._order or 1)
+        candle_left = (
+            slot_left + series_margin + serie_index * candle_slot_width
+        )
+        serie_margin = candle_slot_width * self._serie_margin
+        candle_left += serie_margin
+        candle_width = max(candle_slot_width - 2 * serie_margin, 1)
+        center_x = candle_left + candle_width / 2
+
+        high_y = self.view.y(high)
+        low_y = self.view.y(low)
+        open_y = self.view.y(open_)
+        close_y = self.view.y(close)
+        body_y = min(open_y, close_y)
+        body_height = max(abs(close_y - open_y), 1)
+
+        alter(
+            self.svg.line(
+                node,
+                coords=[(center_x, high_y), (center_x, low_y)],
+                class_='wick reactive',
+                attrib={'stroke-width': 1.5}
+            ), metadata
+        )
+
+        body_class = 'body reactive tooltip-trigger'
+        if close >= open_:
+            body_class += ' subtle-fill'
+        alter(
+            self.svg.node(
+                node,
+                tag='rect',
+                x=candle_left,
+                y=body_y,
+                width=candle_width,
+                height=body_height,
+                class_=body_class,
+                attrib={'stroke-width': 1.5}
+            ), metadata
+        )
+
+        return center_x, (high_y + low_y) / 2

--- a/pygal/test/test_candlestick.py
+++ b/pygal/test/test_candlestick.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+# This file is part of pygal
+#
+# A python svg graph plotting library
+# Copyright © 2012-2025 Kozea
+#
+# This library is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with pygal. If not, see <http://www.gnu.org/licenses/>.
+"""Candlestick chart related tests"""
+
+import pytest
+
+import pygal
+from pygal import Candlestick
+
+
+def test_simple_candlestick():
+    """Simple candlestick test."""
+    chart = Candlestick()
+    chart.add('AAPL', [
+        (10, 15, 8, 12),
+        (12, 18, 10, 11),
+        None,
+        (11, 14, 9, 14),
+    ])
+    chart.x_labels = ['Mon', 'Tue', 'Wed', 'Thu']
+    q = chart.render_pyquery()
+
+    assert len(q('.axis.y')) == 1
+    assert len(q('.legend')) == 1
+    assert len(q('.candlesticks .candle')) == 3
+    assert len(q('.candlesticks .candle.up')) == 2
+    assert len(q('.candlesticks .candle.down')) == 1
+    assert len(q('.candlesticks rect.body')) == 3
+    assert len(q('.candlesticks path.wick')) == 3
+
+
+def test_candlestick_is_public_chart():
+    """Candlestick is exported by the public API."""
+    assert pygal.Candlestick is Candlestick
+    assert 'Candlestick' in pygal.CHARTS_BY_NAME
+
+
+def test_candlestick_axis_uses_all_ohlc_values():
+    """Open/high/low/close values all contribute to y-axis bounds."""
+    chart = Candlestick()
+    chart.add('AAPL', [(10, 100, 1, 11)])
+    chart.render()
+
+    assert chart.state is None
+    chart.setup()
+    try:
+        assert chart._min == 1
+        assert chart._max == 100
+        assert chart._box.ymin <= 1
+        assert chart._box.ymax >= 100
+    finally:
+        chart.teardown()
+
+
+def test_candlestick_tooltip_formats_ohlc_values():
+    """Tooltip text contains each OHLC component."""
+    chart = Candlestick()
+    chart.add('AAPL', [(10, 15, 8, 12)])
+    svg = chart.render(is_unicode=True)
+
+    assert 'Open: 10' in svg
+    assert 'High: 15' in svg
+    assert 'Low: 8' in svg
+    assert 'Close: 12' in svg
+
+
+def test_candlestick_multiple_series_are_grouped():
+    """Multiple OHLC series share each x slot."""
+    chart = Candlestick()
+    chart.add('AAPL', [(10, 15, 8, 12), (12, 18, 10, 11)])
+    chart.add('GOOG', [(20, 25, 18, 24), (24, 28, 22, 23)])
+    q = chart.render_pyquery()
+
+    assert len(q('.legend')) == 2
+    assert len(q('.candlesticks .candle')) == 4
+
+
+def test_candlestick_accepts_single_values_as_doji():
+    """Single numeric values render as doji candles."""
+    chart = Candlestick()
+    chart.add('AAPL', [10, 12, None, 11])
+    q = chart.render_pyquery()
+
+    assert len(q('.candlesticks .candle')) == 3
+    assert len(q('.candlesticks .candle.up')) == 3
+    assert len(q('.candlesticks rect.body')) == 3
+
+
+def test_candlestick_rejects_bad_shape():
+    """Candlestick values must be OHLC tuples."""
+    chart = Candlestick()
+    chart.add('bad', [(1, 2, 3)])
+
+    with pytest.raises(ValueError):
+        chart.render()
+
+
+def test_candlestick_rejects_inconsistent_high_low():
+    """High and low must contain open and close values."""
+    chart = Candlestick()
+    chart.add('bad', [(10, 9, 8, 12)])
+
+    with pytest.raises(ValueError):
+        chart.render()


### PR DESCRIPTION
Closes #426.

This adds a `Candlestick` chart type for OHLC data. I noticed the issue thread asked for multiple solutions and visual examples, so I also rendered a grouped OHLC preview from this branch before opening the PR.

Summary:
- accepts `(open, high, low, close)` values
- renders `None` values as gaps
- renders single numeric values as doji candles for compatibility with pygal's generic chart helpers
- includes open/high/low/close values in y-axis scaling
- supports grouped multiple series
- validates malformed OHLC tuples and inconsistent high/low bounds
- adds tooltip formatting and documentation

Rendered preview:

<img width="800" height="420" alt="candlestick-preview" src="https://github.com/user-attachments/assets/4f69a899-ae04-4cbe-9264-f4943180462e" />

Validation:
- `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/Cellar/cairo/1.18.4/lib:/opt/homebrew/lib .venv/bin/python -m pytest pygal/test`
- `git diff --check`
- `.venv/bin/ruff check pygal/graph/candlestick.py pygal/test/test_candlestick.py pygal/__init__.py`

Observed locally:
- `4558 passed`
- `git diff --check` passed
- `ruff check` passed